### PR TITLE
Implement paystub draft save/load

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,8 @@
                 </div>
 
                 <button id="resetAllFields" class="btn btn-secondary btn-full-width">Reset All Fields</button>
+                <button id="saveDraft" class="btn btn-secondary btn-full-width">Save Draft</button>
+                <button id="loadDraft" class="btn btn-secondary btn-full-width">Load Draft</button>
                 <button id="previewPdfWatermarked" class="btn btn-secondary btn-full-width">Preview PDF (Watermarked)</button>
                 <button id="generateAndPay" class="btn btn-primary btn-full-width">Generate & Proceed to Payment</button>
             </div>

--- a/script.js
+++ b/script.js
@@ -60,6 +60,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Buttons
     const resetAllFieldsBtn = document.getElementById('resetAllFields');
+    const saveDraftBtn = document.getElementById('saveDraft');
+    const loadDraftBtn = document.getElementById('loadDraft');
     const previewPdfWatermarkedBtn = document.getElementById('previewPdfWatermarked');
     const generateAndPayBtn = document.getElementById('generateAndPay');
 
@@ -126,6 +128,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Sidebar Button Actions
     resetAllFieldsBtn.addEventListener('click', resetAllFormFields);
+    saveDraftBtn.addEventListener('click', saveDraft);
+    loadDraftBtn.addEventListener('click', loadDraft);
     previewPdfWatermarkedBtn.addEventListener('click', () => generateAndDownloadPdf(true));
     generateAndPayBtn.addEventListener('click', handleMainFormSubmit);
 
@@ -912,6 +916,70 @@ document.addEventListener('DOMContentLoaded', () => {
         toggleEmploymentFields(); // Ensure correct fields are shown based on default radio
         updateHourlyPayFrequencyVisibility(); // And update conditional dropdown
         updateLivePreview(); // Refresh live preview
+    }
+
+    function saveDraft() {
+        const data = gatherFormData();
+        try {
+            localStorage.setItem('buellDocsPaystubDraft', JSON.stringify(data));
+            alert('Draft saved!');
+        } catch (e) {
+            console.error('Failed to save draft', e);
+        }
+    }
+
+    function loadDraft() {
+        const draftStr = localStorage.getItem('buellDocsPaystubDraft');
+        if (!draftStr) {
+            alert('No draft found.');
+            return;
+        }
+        let data;
+        try {
+            data = JSON.parse(draftStr);
+        } catch (e) {
+            console.error('Failed to parse draft', e);
+            return;
+        }
+
+        for (const [key, value] of Object.entries(data)) {
+            const el = paystubForm.elements[key];
+            if (!el) continue;
+            if (el.type === 'radio') {
+                const radio = document.querySelector(`input[name="${key}"][value="${value}"]`);
+                if (radio) radio.checked = true;
+            } else if (el.type === 'checkbox') {
+                el.checked = !!value;
+            } else if (el.tagName === 'SELECT') {
+                el.value = value;
+            } else if (el.type !== 'file') {
+                el.value = value;
+            }
+        }
+
+        if (data.companyLogoDataUrl) {
+            companyLogoPreviewImg.src = data.companyLogoDataUrl;
+            companyLogoPreviewImg.style.display = 'block';
+            companyLogoPlaceholder.style.display = 'none';
+        } else {
+            companyLogoPreviewImg.src = '#';
+            companyLogoPreviewImg.style.display = 'none';
+            companyLogoPlaceholder.style.display = 'block';
+        }
+
+        if (data.payrollProviderLogoDataUrl) {
+            payrollProviderLogoPreviewImg.src = data.payrollProviderLogoDataUrl;
+            payrollProviderLogoPreviewImg.style.display = 'block';
+            payrollProviderLogoPlaceholder.style.display = 'none';
+        } else {
+            payrollProviderLogoPreviewImg.src = '#';
+            payrollProviderLogoPreviewImg.style.display = 'none';
+            payrollProviderLogoPlaceholder.style.display = 'block';
+        }
+
+        toggleEmploymentFields();
+        updateHourlyPayFrequencyVisibility();
+        updateLivePreview();
     }
 
 


### PR DESCRIPTION
## Summary
- add Save Draft and Load Draft buttons
- wire up new buttons in the script
- implement saveDraft and loadDraft using LocalStorage

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6841ad0335bc8320ac0e19edc1d2eb70