### PR TITLE
Add income representation step

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,42 @@
             </section>
 
             <form id="paystubForm">
+                <!-- Step 1: Desired Income Representation -->
+                <section class="form-section-card">
+                    <h3>Step 1: Define Your Desired Income Representation</h3>
+                    <div class="grid-col-2">
+                        <div class="form-group">
+                            <label for="desiredIncomeAmount">Desired Income Amount <span class="required-asterisk">*</span></label>
+                            <input type="number" id="desiredIncomeAmount" name="desiredIncomeAmount" step="0.01" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="desiredIncomePeriod">Income Period <span class="required-asterisk">*</span></label>
+                            <select id="desiredIncomePeriod" name="desiredIncomePeriod">
+                                <option value="Annual" selected>Annual</option>
+                                <option value="Monthly">Monthly</option>
+                                <option value="Weekly">Weekly</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label>Represent As <span class="required-asterisk">*</span></label>
+                        <div class="radio-group">
+                            <label><input type="radio" id="repAsSalaried" name="incomeRepresentationType" value="Salaried" checked> Salaried</label>
+                            <label><input type="radio" id="repAsHourly" name="incomeRepresentationType" value="Hourly"> Hourly</label>
+                        </div>
+                    </div>
+                    <div class="form-group" id="assumedHourlyHoursGroup" style="display:none;">
+                        <label for="assumedHourlyRegularHours">Assumed Regular Hours per Period for Representation</label>
+                        <input type="number" id="assumedHourlyRegularHours" name="assumedHourlyRegularHours" step="0.01" min="0" value="40">
+                    </div>
+                    <div class="form-group checkbox-group">
+                        <label for="isForNJEmployment">
+                            <input type="checkbox" id="isForNJEmployment" name="isForNJEmployment" checked>
+                            This representation is for New Jersey employment (auto-populates standard NJ taxes/deductions).
+                        </label>
+                    </div>
+                    <button type="button" id="populateDetailsBtn" class="btn btn-secondary">Auto-Populate Paystub Details Based on Above</button>
+                </section>
                 <!-- Employer Information -->
                 <section class="form-section-card">
                     <h3>Employer Information</h3>

--- a/script.js
+++ b/script.js
@@ -19,6 +19,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const hourlyFieldsDiv = document.getElementById('hourlyFields');
     const salariedFieldsDiv = document.getElementById('salariedFields');
 
+    // Desired Income Representation Elements
+    const desiredIncomeAmountInput = document.getElementById('desiredIncomeAmount');
+    const desiredIncomePeriodSelect = document.getElementById('desiredIncomePeriod');
+    const incomeRepresentationRadios = document.querySelectorAll('input[name="incomeRepresentationType"]');
+    const assumedHourlyHoursGroup = document.getElementById('assumedHourlyHoursGroup');
+    const assumedHourlyRegularHoursInput = document.getElementById('assumedHourlyRegularHours');
+    const isForNjEmploymentCheckbox = document.getElementById('isForNJEmployment');
+    const populateDetailsBtn = document.getElementById('populateDetailsBtn');
+
     // Logo Preview Elements
     const companyLogoInput = document.getElementById('companyLogo');
     const companyLogoPreviewContainer = document.getElementById('companyLogoPreviewContainer');
@@ -123,6 +132,10 @@ document.addEventListener('DOMContentLoaded', () => {
     employmentTypeRadios.forEach(radio => {
         radio.addEventListener('change', toggleEmploymentFields);
     });
+    incomeRepresentationRadios.forEach(radio => {
+        radio.addEventListener('change', toggleRepresentationFields);
+    });
+    populateDetailsBtn.addEventListener('click', populateDetailsFromDesiredIncome);
 
     // Update Hourly Pay Frequency Visibility
     numPaystubsSelect.addEventListener('change', updateHourlyPayFrequencyVisibility);
@@ -208,6 +221,48 @@ document.addEventListener('DOMContentLoaded', () => {
             setRequired(hourlyPayFrequencySelect, false);
         }
         updateLivePreview(); // Update stub indicator
+    }
+
+    function toggleRepresentationFields() {
+        const selected = document.querySelector('input[name="incomeRepresentationType"]:checked').value;
+        if (selected === 'Hourly') {
+            assumedHourlyHoursGroup.style.display = 'block';
+        } else {
+            assumedHourlyHoursGroup.style.display = 'none';
+        }
+    }
+
+    function populateDetailsFromDesiredIncome() {
+        const amount = parseFloat(desiredIncomeAmountInput.value) || 0;
+        const period = desiredIncomePeriodSelect.value;
+        const type = document.querySelector('input[name="incomeRepresentationType"]:checked').value;
+        const hours = parseFloat(assumedHourlyRegularHoursInput.value) || 40;
+
+        let annualAmount = amount;
+        if (period === 'Monthly') annualAmount = amount * 12;
+        else if (period === 'Weekly') annualAmount = amount * 52;
+
+        if (type === 'Salaried') {
+            document.querySelector('input[name="employmentType"][value="Salaried"]').checked = true;
+            toggleEmploymentFields();
+            document.getElementById('annualSalary').value = annualAmount.toFixed(2);
+        } else {
+            document.querySelector('input[name="employmentType"][value="Hourly"]').checked = true;
+            toggleEmploymentFields();
+            const hourlyRate = annualAmount / (hours * 52);
+            document.getElementById('hourlyRate').value = hourlyRate.toFixed(2);
+            document.getElementById('regularHours').value = hours;
+        }
+
+        if (isForNjEmploymentCheckbox.checked) {
+            const stateTaxNameInput = document.getElementById('stateTaxName');
+            if (stateTaxNameInput && !stateTaxNameInput.value) {
+                stateTaxNameInput.value = 'NJ State Tax';
+            }
+        }
+
+        updateHourlyPayFrequencyVisibility();
+        updateLivePreview();
     }
 
     function handleLogoUpload(event, previewImgElement, placeholderElement) {
@@ -1192,5 +1247,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Initial Setup Calls --- //
     toggleEmploymentFields(); // Set initial state of employment fields
     updateHourlyPayFrequencyVisibility(); // Set initial state of hourly frequency dropdown
+    toggleRepresentationFields(); // Set initial state of representation fields
 
 });


### PR DESCRIPTION
## Summary
- add income-representation section at top of form
- wire up JS for populating fields from the desired income info

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841d941df888320a2e25d500d1be407