### PR TITLE
Add NJ auto-population logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -72,6 +72,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const estimateDeductionsBtn = document.getElementById('estimateDeductions');
     const previewPdfWatermarkedBtn = document.getElementById('previewPdfWatermarked');
     const generateAndPayBtn = document.getElementById('generateAndPay');
+    const populateDetailsBtn = document.getElementById('populateDetailsBtn');
 
     // Modal Elements
     const paymentModal = document.getElementById('paymentModal');
@@ -151,6 +152,7 @@ document.addEventListener('DOMContentLoaded', () => {
     estimateDeductionsBtn.addEventListener('click', estimateAllDeductions);
     previewPdfWatermarkedBtn.addEventListener('click', () => generateAndDownloadPdf(true));
     generateAndPayBtn.addEventListener('click', handleMainFormSubmit);
+    if (populateDetailsBtn) populateDetailsBtn.addEventListener('click', autoPopulateFromDesiredIncome);
 
     // Modal Interactions
     closePaymentModalBtn.addEventListener('click', () => paymentModal.style.display = 'none');
@@ -1039,6 +1041,123 @@ document.addEventListener('DOMContentLoaded', () => {
         toggleEmploymentFields();
         updateHourlyPayFrequencyVisibility();
         updateLivePreview();
+    }
+
+    function autoPopulateFromDesiredIncome() {
+        const amount = parseFloat(document.getElementById('desiredIncomeAmount').value);
+        const period = document.getElementById('desiredIncomePeriod').value;
+        const repType = document.getElementById('incomeRepresentationType').value;
+        const assumedHours = parseFloat(document.getElementById('assumedHourlyRegularHours').value) || 40;
+        const forNJ = document.getElementById('isForNJEmployment').checked;
+
+        if (isNaN(amount) || amount <= 0) {
+            showNotificationModal('Invalid Input', 'Desired income amount must be greater than 0.');
+            return;
+        }
+
+        const periodsMap = { ...PAY_PERIODS_PER_YEAR, 'Annual': 1, 'Hourly': PAY_PERIODS_PER_YEAR['Weekly'] };
+        const periods = periodsMap[period] || 1;
+        const effectiveAnnualSalary = period === 'Hourly'
+            ? amount * assumedHours * PAY_PERIODS_PER_YEAR['Weekly']
+            : amount * periods;
+
+        let payFrequency = 'Bi-Weekly';
+        let grossPayPerPeriod = 0;
+
+        if (repType === 'Salaried') {
+            document.querySelector('input[name="employmentType"][value="Salaried"]').checked = true;
+            const annualSalaryInput = document.getElementById('annualSalary');
+            annualSalaryInput.value = effectiveAnnualSalary.toFixed(2);
+            const payFreqSelect = document.getElementById('salariedPayFrequency');
+            if (payFreqSelect.value) payFrequency = payFreqSelect.value; else payFreqSelect.value = payFrequency;
+            grossPayPerPeriod = effectiveAnnualSalary / PAY_PERIODS_PER_YEAR[payFrequency];
+        } else {
+            document.querySelector('input[name="employmentType"][value="Hourly"]').checked = true;
+            const payFreqSelect = document.getElementById('hourlyPayFrequency');
+            payFrequency = payFreqSelect.value || 'Weekly';
+            payFreqSelect.value = payFrequency;
+            grossPayPerPeriod = effectiveAnnualSalary / PAY_PERIODS_PER_YEAR[payFrequency];
+            const hourlyRate = grossPayPerPeriod / assumedHours;
+            document.getElementById('hourlyRate').value = hourlyRate.toFixed(2);
+            document.getElementById('regularHours').value = assumedHours;
+        }
+
+        if (forNJ) {
+            const fedStatusEl = document.querySelector('input[name="federalFilingStatus"]:checked') ||
+                                document.getElementById('federalFilingStatus');
+            const filingStatus = fedStatusEl ? fedStatusEl.value : 'Single';
+            const ytdSS = parseFloat(document.getElementById('initialYtdSocialSecurity').value) || 0;
+
+            const fedTax = estimateFederalTax(grossPayPerPeriod, payFrequency, filingStatus);
+            const stateTax = estimateNJStateTax(grossPayPerPeriod, payFrequency, filingStatus);
+            const ssTax = estimateSocialSecurity(grossPayPerPeriod, ytdSS);
+            const medicareTax = estimateMedicare(grossPayPerPeriod);
+            const sdi = estimateNJ_SDI(grossPayPerPeriod);
+            const fli = estimateNJ_FLI(grossPayPerPeriod);
+            const ui = estimateNJ_UIHCWF(grossPayPerPeriod);
+
+            document.getElementById('federalTaxAmount').value = fedTax.toFixed(2);
+            document.getElementById('stateTaxAmount').value = stateTax.toFixed(2);
+            document.getElementById('stateTaxName').value = 'NJ State Tax';
+            document.getElementById('socialSecurityAmount').value = ssTax.toFixed(2);
+            document.getElementById('medicareAmount').value = medicareTax.toFixed(2);
+            document.getElementById('njSdiAmount').value = sdi.toFixed(2);
+            document.getElementById('njFliAmount').value = fli.toFixed(2);
+            document.getElementById('njUiHcWfAmount').value = ui.toFixed(2);
+
+            ['federalTaxAmount','stateTaxAmount','socialSecurityAmount','medicareAmount','njSdiAmount','njFliAmount','njUiHcWfAmount']
+                .forEach(id => {
+                    const el = document.getElementById(id);
+                    if (el) { el.classList.add('auto-populated'); el.readOnly = true; }
+                });
+        } else {
+            ['federalTaxAmount','stateTaxAmount','socialSecurityAmount','medicareAmount','njSdiAmount','njFliAmount','njUiHcWfAmount']
+                .forEach(id => {
+                    const el = document.getElementById(id);
+                    if (el) { el.classList.remove('auto-populated'); el.readOnly = false; }
+                });
+            document.getElementById('stateTaxName').value = '';
+            document.getElementById('njSdiAmount').value = 0;
+            document.getElementById('njFliAmount').value = 0;
+            document.getElementById('njUiHcWfAmount').value = 0;
+        }
+
+        toggleEmploymentFields();
+        updateHourlyPayFrequencyVisibility();
+        updateLivePreview();
+    }
+
+    function estimateFederalTax(grossPayPerPeriod, payFrequency, status) {
+        return grossPayPerPeriod * FEDERAL_TAX_RATE;
+    }
+
+    function estimateNJStateTax(grossPayPerPeriod, payFrequency, status) {
+        const annual = grossPayPerPeriod * (PAY_PERIODS_PER_YEAR[payFrequency] || 1);
+        const rate = annual > 40000 ? 0.055 : 0.03;
+        return (annual * rate) / (PAY_PERIODS_PER_YEAR[payFrequency] || 1);
+    }
+
+    function estimateSocialSecurity(grossPayPerPeriod, ytdSocialSecuritySoFar) {
+        const wagesSoFar = ytdSocialSecuritySoFar / SOCIAL_SECURITY_RATE;
+        if (wagesSoFar >= SOCIAL_SECURITY_WAGE_LIMIT) return 0;
+        const taxable = Math.min(grossPayPerPeriod, SOCIAL_SECURITY_WAGE_LIMIT - wagesSoFar);
+        return taxable * SOCIAL_SECURITY_RATE;
+    }
+
+    function estimateMedicare(grossPayPerPeriod) {
+        return grossPayPerPeriod * MEDICARE_RATE;
+    }
+
+    function estimateNJ_SDI(grossPayPerPeriod) {
+        return grossPayPerPeriod * 0.003;
+    }
+
+    function estimateNJ_FLI(grossPayPerPeriod) {
+        return grossPayPerPeriod * 0.0015;
+    }
+
+    function estimateNJ_UIHCWF(grossPayPerPeriod) {
+        return grossPayPerPeriod * 0.000425;
     }
 
     function estimateAllDeductions() {

--- a/styles.css
+++ b/styles.css
@@ -895,8 +895,12 @@ input.invalid, select.invalid, textarea.invalid {
         width: 45%; /* Width of the label */
         white-space: nowrap;
     }
-    .earnings-table-preview td:last-child, .deductions-table-preview td:last-child {
-        border-bottom: 0;
-    }
+.earnings-table-preview td:last-child, .deductions-table-preview td:last-child {
+    border-bottom: 0;
+}
+
+.auto-populated {
+    background-color: rgba(174, 142, 93, 0.2);
+}
 
 }


### PR DESCRIPTION
## Summary
- hook up **populateDetailsBtn**
- auto-populate pay details and NJ taxes from desired income
- add helper estimators for Federal/NJ tax calculations
- visually mark auto-filled deductions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841d96d52548320976c8d87c0ad7ccf