### PR TITLE
Implement NJ employment toggle logic

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,16 @@
     --sidebar-width: 280px;
 }
 
+/* Utility styles for auto-calculated fields and highlighted buttons */
+.auto-calculated-field {
+    background-color: var(--bg-secondary);
+    color: var(--text-secondary);
+}
+
+.highlight-btn {
+    box-shadow: 0 0 10px var(--accent-gold);
+}
+
 /* -------------------- */
 /* --- GLOBAL RESETS & BASE --- */
 /* -------------------- */


### PR DESCRIPTION
## Summary
- add support for NJ employment checkbox and populate details button
- auto-populate NJ taxes when checked and clear fields when unchecked
- style auto-calculated fields and highlight populate button
- reset new controls in form reset handler

## Testing
- `node --check script.js`
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6841d9b62edc8320bd241ea2d3cbb4d3