### PR TITLE
Add standard deduction estimator

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -917,4 +917,8 @@ input.invalid, select.invalid, textarea.invalid {
     background-color: rgba(174, 142, 93, 0.2);
 }
 
+.auto-calculated-field {
+    background-color: rgba(174, 142, 93, 0.2);
+}
+
 }


### PR DESCRIPTION
## Summary
- add ability to estimate standard deductions with new `estimateAllStandardDeductions()`
- highlight auto-calculated inputs
- wire new `estimateAllDeductionsBtn` button

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841ebbd794c8320961ea8ff24c3aaba