### PR TITLE
Update hero text and populate workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Paystubs - BuellDocs Client Dashboard</title>
+    <title>BuellDocs Paystub Generator (Canvas)</title>
     <link rel="stylesheet" href="styles.css">
     <!-- CDNs for jsPDF and jsPDF-AutoTable -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
@@ -61,8 +61,8 @@
 
         <main class="main-content">
             <section class="hero-section">
-                <h1>Income Statement Generator</h1>
-                <p>Generate your professional paystubs quickly and securely. Fill in the details below to begin.</p>
+                <h1>BuellDocs Paystub Generator (Canvas)</h1>
+                <p>Follow the new workflow below to quickly create your draft paystub.</p>
             </section>
 
             <form id="paystubForm">
@@ -100,7 +100,7 @@
                             This representation is for New Jersey employment (auto-populates standard NJ taxes/deductions).
                         </label>
                     </div>
-                    <button type="button" id="populateDetailsBtn" class="btn btn-secondary">Auto-Populate Paystub Details Based on Above</button>
+                    <button type="button" id="populateDetailsBtn" class="btn btn-primary">Calculate &amp; Fill Paystub Details &#10132;</button>
                 </section>
                 <!-- Employer Information -->
                 <section class="form-section-card">

--- a/script.js
+++ b/script.js
@@ -28,6 +28,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const isForNjEmploymentCheckbox = document.getElementById('isForNJEmployment');
     const populateDetailsBtn = document.getElementById('populateDetailsBtn');
 
+    function enablePopulateBtn() {
+        if (populateDetailsBtn) {
+            populateDetailsBtn.disabled = false;
+            populateDetailsBtn.textContent = 'Calculate & Fill Paystub Details \u2794';
+        }
+    }
+
+    [desiredIncomeAmountInput, desiredIncomePeriodSelect, assumedHourlyRegularHoursInput,
+     isForNjEmploymentCheckbox, ...incomeRepresentationRadios].forEach(el => {
+        el.addEventListener('input', enablePopulateBtn);
+        el.addEventListener('change', enablePopulateBtn);
+    });
+
     // Logo Preview Elements
     const companyLogoInput = document.getElementById('companyLogo');
     const companyLogoPreviewContainer = document.getElementById('companyLogoPreviewContainer');
@@ -136,7 +149,7 @@ document.addEventListener('DOMContentLoaded', () => {
     incomeRepresentationRadios.forEach(radio => {
         radio.addEventListener('change', toggleRepresentationFields);
     });
-    populateDetailsBtn.addEventListener('click', populateDetailsFromDesiredIncome);
+    populateDetailsBtn.addEventListener('click', autoPopulateFromDesiredIncome);
 
     // Update Hourly Pay Frequency Visibility
     numPaystubsSelect.addEventListener('change', updateHourlyPayFrequencyVisibility);
@@ -166,7 +179,6 @@ document.addEventListener('DOMContentLoaded', () => {
     estimateDeductionsBtn.addEventListener('click', estimateAllDeductions);
     previewPdfWatermarkedBtn.addEventListener('click', () => generateAndDownloadPdf(true));
     generateAndPayBtn.addEventListener('click', handleMainFormSubmit);
-    if (populateDetailsBtn) populateDetailsBtn.addEventListener('click', autoPopulateFromDesiredIncome);
 
     // Modal Interactions
     closePaymentModalBtn.addEventListener('click', () => paymentModal.style.display = 'none');
@@ -266,6 +278,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         updateHourlyPayFrequencyVisibility();
         updateLivePreview();
+
+        if (populateDetailsBtn) {
+            populateDetailsBtn.textContent = 'Recalculate from Desired Income';
+            populateDetailsBtn.disabled = true;
+        }
     }
 
     function handleLogoUpload(event, previewImgElement, placeholderElement) {
@@ -1181,6 +1198,11 @@ document.addEventListener('DOMContentLoaded', () => {
         toggleEmploymentFields();
         updateHourlyPayFrequencyVisibility();
         updateLivePreview();
+
+        if (populateDetailsBtn) {
+            populateDetailsBtn.textContent = 'Recalculate from Desired Income';
+            populateDetailsBtn.disabled = true;
+        }
     }
 
     function estimateFederalTax(grossPayPerPeriod, payFrequency, status) {

--- a/styles.css
+++ b/styles.css
@@ -465,6 +465,12 @@ input.invalid, select.invalid, textarea.invalid {
     display: block;
 }
 
+/* Prominent CTA in Desired Income section */
+#populateDetailsBtn {
+    font-size: 17px;
+    padding: 14px 28px;
+}
+
 /* -------------------- */
 /* --- LIVE PREVIEW SECTION --- */
 /* -------------------- */


### PR DESCRIPTION
## Summary
- clarify page title and hero messaging for the new workflow
- highlight the "Calculate & Fill Paystub Details" button
- style populate button prominently
- disable populate button after generating details and restore when income inputs change

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6841e788bbfc832094fb4f0239a47151