### PR TITLE
Add minimized sections with reveal logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
                     <button type="button" id="populateDetailsBtn" class="btn btn-secondary">Auto-Populate Paystub Details Based on Above</button>
                 </section>
                 <!-- Employer Information -->
-                <section class="form-section-card">
+                <section class="form-section-card form-section-minimized">
                     <h3>Employer Information</h3>
                     <div class="grid-col-2">
                         <div class="form-group">
@@ -158,7 +158,7 @@
                 </section>
 
                 <!-- Employee Information -->
-                <section class="form-section-card">
+                <section class="form-section-card form-section-minimized">
                     <h3>Employee Information</h3>
                     <div class="form-group">
                         <label for="employeeFullName">Employee Full Name <span class="required-asterisk">*</span></label>
@@ -195,7 +195,7 @@
                 </section>
 
                 <!-- Pay Period & Dates (For First/Base Stub) -->
-                <section class="form-section-card">
+                <section class="form-section-card form-section-minimized">
                     <h3>Pay Period & Dates (For First/Base Stub)</h3>
                     <p class="info-text">For multiple stubs, subsequent dates auto-increment based on pay frequency.</p>
                     <div class="grid-col-3">
@@ -218,7 +218,7 @@
                 </section>
 
                 <!-- Earnings -->
-                <section class="form-section-card">
+                <section class="form-section-card form-section-minimized">
                     <h3>Earnings</h3>
                     <div class="form-group">
                         <label>Employment Type <span class="required-asterisk">*</span></label>
@@ -290,7 +290,7 @@
                 </section>
 
                 <!-- Taxes (Enter Amounts per Period - Simulation Only) -->
-                <section class="form-section-card">
+                <section class="form-section-card form-section-minimized">
                     <h3>Taxes (Enter Amounts per Period - Simulation Only)</h3>
                      <div class="grid-col-2">
                         <div class="form-group">
@@ -336,7 +336,7 @@
                 </section>
 
                 <!-- State-Specific Deductions/Taxes (New Jersey) -->
-                <section class="form-section-card">
+                <section class="form-section-card form-section-minimized">
                     <h3>State-Specific Deductions/Taxes (New Jersey - Enter Amounts per Period)</h3>
                     <div class="grid-col-3">
                         <div class="form-group">
@@ -358,7 +358,7 @@
                 </section>
 
                 <!-- Other Deductions (Optional) -->
-                <section class="form-section-card">
+                <section class="form-section-card form-section-minimized">
                     <h3>Other Deductions (Enter Amounts per Period - Optional)</h3>
                     <div class="grid-col-2">
                         <div class="form-group">
@@ -387,7 +387,7 @@
                 </section>
 
                 <!-- Initial Year-to-Date (YTD) Figures -->
-                <section class="form-section-card">
+                <section class="form-section-card form-section-minimized">
                     <h3>Initial Year-to-Date (YTD) Figures</h3>
                     <p class="info-text">Enter YTD amounts *before* the first paystub in this batch. These accumulate for multiple stubs.</p>
                     <div class="grid-col-2">
@@ -433,7 +433,7 @@
                 </section>
 
                 <!-- Optional Additions -->
-                <section class="form-section-card">
+                <section class="form-section-card form-section-minimized">
                     <h3>Optional Additions</h3>
                      <div class="grid-col-2">
                         <div class="form-group">
@@ -455,7 +455,7 @@
                 </section>
 
                 <!-- User Notes & Submission -->
-                <section class="form-section-card">
+                <section class="form-section-card form-section-minimized">
                     <h3>Notes & Submission</h3>
                     <div class="form-group">
                         <label for="userNotes">Additional instructions or custom requests (optional)</label>

--- a/script.js
+++ b/script.js
@@ -81,7 +81,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const estimateDeductionsBtn = document.getElementById('estimateDeductions');
     const previewPdfWatermarkedBtn = document.getElementById('previewPdfWatermarked');
     const generateAndPayBtn = document.getElementById('generateAndPay');
-    const populateDetailsBtn = document.getElementById('populateDetailsBtn');
 
     // Modal Elements
     const paymentModal = document.getElementById('paymentModal');
@@ -103,6 +102,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const successTxIdSpan = document.getElementById('successTxId');
     const successNumStubsSpan = document.getElementById('successNumStubs');
     const successUserNotesSpan = document.getElementById('successUserNotes');
+
+    // Sections to be minimized until populated
+    const secondarySections = Array.from(document.querySelectorAll('.form-section-card')).slice(1);
+
+    function minimizeSecondarySections() {
+        secondarySections.forEach(sec => sec.classList.add('form-section-minimized'));
+    }
+
+    function revealSecondarySections() {
+        secondarySections.forEach(sec => sec.classList.remove('form-section-minimized'));
+    }
 
 
     // --- Initial State & Configuration --- //
@@ -1032,6 +1042,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         toggleEmploymentFields(); // Ensure correct fields are shown based on default radio
         updateHourlyPayFrequencyVisibility(); // And update conditional dropdown
+        minimizeSecondarySections();
         updateLivePreview(); // Refresh live preview
     }
 
@@ -1096,6 +1107,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         toggleEmploymentFields();
         updateHourlyPayFrequencyVisibility();
+        revealSecondarySections();
         updateLivePreview();
     }
 
@@ -1180,6 +1192,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         toggleEmploymentFields();
         updateHourlyPayFrequencyVisibility();
+        revealSecondarySections();
         updateLivePreview();
     }
 
@@ -1454,5 +1467,6 @@ document.addEventListener('DOMContentLoaded', () => {
     toggleEmploymentFields(); // Set initial state of employment fields
     updateHourlyPayFrequencyVisibility(); // Set initial state of hourly frequency dropdown
     toggleRepresentationFields(); // Set initial state of representation fields
+    minimizeSecondarySections();
 
 });

--- a/styles.css
+++ b/styles.css
@@ -228,11 +228,36 @@ body {
     padding: 25px;
     margin-bottom: 30px;
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-    transition: box-shadow 0.3s ease;
+    transition: box-shadow 0.3s ease, max-height 0.5s ease, opacity 0.5s ease;
+    overflow: hidden;
+    max-height: 3000px; /* large enough to show full content when expanded */
 }
 
 .form-section-card:hover {
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+}
+
+/* Minimized state for sections auto-populated later */
+.form-section-minimized {
+    opacity: 0.6;
+    max-height: 60px;
+    pointer-events: none;
+    position: relative;
+}
+.form-section-minimized::after {
+    content: 'Details will populate here';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.4);
+    color: var(--text-secondary);
+    font-size: 14px;
+    pointer-events: none;
 }
 
 .form-section-card h3,


### PR DESCRIPTION
## Summary
- collapse secondary form sections until desired income is set
- add new `.form-section-minimized` style and transitions
- unminimize sections when details are auto-populated
- re-minimize when resetting fields

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6841e77371208320aeae60ea6fba47e2