### PR TITLE
Improve FICA estimate helpers

### DIFF
--- a/script.js
+++ b/script.js
@@ -122,7 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const SOCIAL_SECURITY_RATE = 0.062;
-    const SOCIAL_SECURITY_WAGE_LIMIT = 168600; // 2024 limit
+    const SOCIAL_SECURITY_WAGE_LIMIT_2024 = 168600; // 2024 limit
     const MEDICARE_RATE = 0.0145;
     const FEDERAL_TAX_RATE = 0.12; // Simplified flat rate for estimation
     const STATE_TAX_RATE = 0.05;   // Simplified flat rate for estimation
@@ -1142,11 +1142,11 @@ document.addEventListener('DOMContentLoaded', () => {
             const fedStatusEl = document.querySelector('input[name="federalFilingStatus"]:checked') ||
                                 document.getElementById('federalFilingStatus');
             const filingStatus = fedStatusEl ? fedStatusEl.value : 'Single';
-            const ytdSS = parseFloat(document.getElementById('initialYtdSocialSecurity').value) || 0;
+            const ytdGross = parseFloat(document.getElementById('initialYtdGrossPay').value) || 0;
 
             const fedTax = estimateFederalTax(grossPayPerPeriod, payFrequency, filingStatus);
             const stateTax = estimateNJStateTax(grossPayPerPeriod, payFrequency, filingStatus);
-            const ssTax = estimateSocialSecurity(grossPayPerPeriod, ytdSS);
+            const ssTax = estimateSocialSecurity(grossPayPerPeriod, ytdGross);
             const medicareTax = estimateMedicare(grossPayPerPeriod);
             const sdi = estimateNJ_SDI(grossPayPerPeriod);
             const fli = estimateNJ_FLI(grossPayPerPeriod);
@@ -1193,11 +1193,10 @@ document.addEventListener('DOMContentLoaded', () => {
         return (annual * rate) / (PAY_PERIODS_PER_YEAR[payFrequency] || 1);
     }
 
-    function estimateSocialSecurity(grossPayPerPeriod, ytdSocialSecuritySoFar) {
-        const wagesSoFar = ytdSocialSecuritySoFar / SOCIAL_SECURITY_RATE;
-        if (wagesSoFar >= SOCIAL_SECURITY_WAGE_LIMIT) return 0;
-        const taxable = Math.min(grossPayPerPeriod, SOCIAL_SECURITY_WAGE_LIMIT - wagesSoFar);
-        return taxable * SOCIAL_SECURITY_RATE;
+    function estimateSocialSecurity(grossPayPerPeriod, annualizedGrossPayToDateExcludingCurrentPeriod) {
+        const remainingSSLIMIT = SOCIAL_SECURITY_WAGE_LIMIT_2024 - annualizedGrossPayToDateExcludingCurrentPeriod;
+        const taxableForSS = Math.min(grossPayPerPeriod, Math.max(0, remainingSSLIMIT));
+        return taxableForSS * SOCIAL_SECURITY_RATE;
     }
 
     function estimateMedicare(grossPayPerPeriod) {
@@ -1380,11 +1379,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Social Security at flat 6.2% with simplistic wage limit handling
-    function estimateSocialSecurity(grossPayPerPeriod, payFrequency) {
-        const periods = PAY_PERIODS_PER_YEAR[payFrequency] || 1;
-        const maxTaxablePerPeriod = SOCIAL_SECURITY_WAGE_LIMIT / periods;
-        const taxable = Math.min(grossPayPerPeriod, maxTaxablePerPeriod);
-        return taxable * SOCIAL_SECURITY_RATE;
+    function estimateSocialSecurity(grossPayPerPeriod, annualizedGrossPayToDateExcludingCurrentPeriod) {
+        const remainingSSLIMIT = SOCIAL_SECURITY_WAGE_LIMIT_2024 - annualizedGrossPayToDateExcludingCurrentPeriod;
+        const taxableForSS = Math.min(grossPayPerPeriod, Math.max(0, remainingSSLIMIT));
+        return taxableForSS * SOCIAL_SECURITY_RATE;
     }
 
     // Medicare at flat 1.45%


### PR DESCRIPTION
## Summary
- refine FICA helper functions
- compute Social Security tax with yearly wage limit
- use initial YTD gross for SS estimate

## Testing
- `node -v`
- `node --check script.js` *(fails: Identifier 'populateDetailsBtn' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6841ebef992c8320a7bdc522c41d94b5