### PR TITLE
Add net income option with estimation

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,16 @@
                             <input type="number" id="desiredIncomeAmount" name="desiredIncomeAmount" step="0.01" min="0">
                         </div>
                         <div class="form-group">
+                            <label>Is this income amount:</label>
+                            <div class="radio-group">
+                                <input type="radio" name="desiredIncomeType" id="desiredIncomeTypeGross" value="Gross" checked>
+                                <label for="desiredIncomeTypeGross">Before Taxes &amp; Deductions (Gross Income)</label>
+                                <input type="radio" name="desiredIncomeType" id="desiredIncomeTypeNet" value="Net">
+                                <label for="desiredIncomeTypeNet">After Estimated Taxes &amp; Deductions (Target Net Income)</label>
+                            </div>
+                            <p id="netIncomeAdjustmentNote" class="info-text" style="display:none;"></p>
+                        </div>
+                        <div class="form-group">
                             <label for="desiredIncomePeriod">Income Period <span class="required-asterisk">*</span></label>
                             <select id="desiredIncomePeriod" name="desiredIncomePeriod">
                                 <option value="Annual" selected>Annual</option>

--- a/styles.css
+++ b/styles.css
@@ -801,6 +801,15 @@ input.invalid, select.invalid, textarea.invalid {
     font-style: italic;
 }
 
+#netIncomeAdjustmentNote {
+    color: var(--text-secondary);
+    background-color: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--border-color);
+    padding: 6px 8px;
+    border-radius: var(--border-radius-sm);
+    margin-top: 5px;
+}
+
 /* -------------------- */
 /* --- RESPONSIVE DESIGN --- */
 /* -------------------- */


### PR DESCRIPTION
## Summary
- add gross vs net desired income selection in UI
- include net income adjustment note styling
- compute gross estimate iteratively when net desired
- keep note visible in live preview and reset it on form reset

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6841f17e8b388320babee08b8a633670