### PR TITLE
Add performance optimization comments and image resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # docs
 professional docs
+
+## Performance Optimization Notes
+
+* **Image Handling:** If large images are uploaded as logos, they are resized on the client before being converted to a Data URL. When saving drafts, the code checks that the resulting JSON is under roughly 4 MB so LocalStorage does not overflow.
+* **Lazy Loading:** Should large images be added to informational pages (e.g. `about_buelldocs.html`), add `loading="lazy"` on the `<img>` tags to defer loading until they are in view.
+* **Code Splitting:** For future enhancements with heavier JavaScript, dynamic imports such as `import('./module.js').then(...)` can be used to load modules only when necessary. This requires switching the main script to an ES module.

--- a/about_buelldocs.html
+++ b/about_buelldocs.html
@@ -236,6 +236,7 @@
         }
     </style>
 </head>
+<!-- TODO: For any future large images added to this page, use the HTML loading="lazy" attribute, e.g., <img src="image.jpg" loading="lazy" alt="..."> -->
 <body>
     <div class="noise-overlay"></div>
     <div class="backdrop-glow"></div>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,7 @@
     Description: JavaScript logic for the paystub generator application,
                  including form handling, calculations, live preview, and PDF generation.
 */
+/* TODO (Build Process): For production deployment, consider minifying this file to reduce its size and improve load times. */
 
 'use strict';
 
@@ -420,11 +421,28 @@ document.addEventListener('DOMContentLoaded', () => {
         if (file && file.type.startsWith('image/')) {
             const reader = new FileReader();
             reader.onload = (e) => {
-                previewImgElement.src = e.target.result;
-                previewImgElement.style.display = 'block';
-                if (placeholderElement) placeholderElement.style.display = 'none';
-                updateLivePreview(); // Update the main live preview
-            }
+                const img = new Image();
+                img.onload = () => {
+                    const MAX_DIMENSION = 500; // basic client-side resize
+                    let { width, height } = img;
+                    if (width > MAX_DIMENSION || height > MAX_DIMENSION) {
+                        const scale = Math.min(MAX_DIMENSION / width, MAX_DIMENSION / height);
+                        width = Math.round(width * scale);
+                        height = Math.round(height * scale);
+                    }
+                    const canvas = document.createElement('canvas');
+                    canvas.width = width;
+                    canvas.height = height;
+                    const ctx = canvas.getContext('2d');
+                    ctx.drawImage(img, 0, 0, width, height);
+                    const dataUrl = canvas.toDataURL('image/png', 0.8);
+                    previewImgElement.src = dataUrl;
+                    previewImgElement.style.display = 'block';
+                    if (placeholderElement) placeholderElement.style.display = 'none';
+                    updateLivePreview();
+                };
+                img.src = e.target.result;
+            };
             reader.readAsDataURL(file);
             clearError(event.target);
         } else if (file) {
@@ -1252,7 +1270,12 @@ document.addEventListener('DOMContentLoaded', () => {
         data.companyLogoDataUrl = companyLogoPreviewImg.style.display !== 'none' ? companyLogoPreviewImg.src : null;
         data.payrollProviderLogoDataUrl = payrollProviderLogoPreviewImg.style.display !== 'none' ? payrollProviderLogoPreviewImg.src : null;
         try {
-            localStorage.setItem('buellDocsPaystubDraft_v2', JSON.stringify(data));
+            const json = JSON.stringify(data);
+            if (json.length > 4000000) { // ~4MB safety check
+                alert('Draft is too large to save. Please use smaller logo images.');
+                return;
+            }
+            localStorage.setItem('buellDocsPaystubDraft_v2', json);
             const originalText = saveDraftBtn.textContent;
             saveDraftBtn.textContent = 'Draft Saved!';
             setTimeout(() => { saveDraftBtn.textContent = originalText; }, 1500);

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,7 @@
     Description: Styles for the paystub generator application,
                  adhering to the BuellDocs premium brand aesthetic.
 */
+/* TODO (Build Process): For production deployment, consider minifying this file to reduce its size and improve load times. */
 
 /* -------------------- */
 /* --- ROOT VARIABLES --- */


### PR DESCRIPTION
## Summary
- add build-process TODOs for minification in `script.js` and `styles.css`
- resize uploaded logos on the client to avoid huge data URLs
- prevent saving extremely large drafts to LocalStorage
- document lazy loading and dynamic import suggestions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684213793198832097bcce2aa5dbc6b0