### PR TITLE
Implement Social Security & Medicare auto-calc logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -266,6 +266,7 @@ document.addEventListener('DOMContentLoaded', () => {
         5: { price: 125.00, note: "$25 each - Bulk rate applied!" }
     };
     const SOCIAL_SECURITY_WAGE_LIMIT_2024 = 168600; // 2024 limit
+    const SOCIAL_SECURITY_RATE = 0.062;
     const MEDICARE_RATE = 0.0145;
     const FEDERAL_TAX_RATE = 0.12; // Simplified flat rate for estimation
     const STATE_TAX_RATE = 0.05;   // Simplified flat rate for estimation
@@ -343,8 +344,8 @@ document.addEventListener('DOMContentLoaded', () => {
     employmentTypeRadios.forEach(radio => radio.addEventListener('change', updateHourlyPayFrequencyVisibility));
     isForNjEmploymentCheckbox.addEventListener('change', handleNjEmploymentChange);
     if (autoCalculateFederalTaxCheckbox) autoCalculateFederalTaxCheckbox.addEventListener('change', updateAutoCalculatedFields);
-    if (autoCalculateSocialSecurityCheckbox) autoCalculateSocialSecurityCheckbox.addEventListener('change', updateAutoCalculatedFields);
-    if (autoCalculateMedicareCheckbox) autoCalculateMedicareCheckbox.addEventListener('change', updateAutoCalculatedFields);
+    if (autoCalculateSocialSecurityCheckbox) autoCalculateSocialSecurityCheckbox.addEventListener('change', handleSocialSecurityAutoCalcChange);
+    if (autoCalculateMedicareCheckbox) autoCalculateMedicareCheckbox.addEventListener('change', handleMedicareAutoCalcChange);
     if (autoCalculateNjSdiCheckbox) autoCalculateNjSdiCheckbox.addEventListener('change', updateAutoCalculatedFields);
     if (autoCalculateNjFliCheckbox) autoCalculateNjFliCheckbox.addEventListener('change', updateAutoCalculatedFields);
     if (autoCalculateNjUiCheckbox) autoCalculateNjUiCheckbox.addEventListener('change', updateAutoCalculatedFields);
@@ -1944,6 +1945,37 @@ document.addEventListener('DOMContentLoaded', () => {
             if (stateTaxNameInput) stateTaxNameInput.value = '';
         }
         updateAutoCalculatedFields();
+    }
+
+    function handleSocialSecurityAutoCalcChange() {
+        if (autoCalculateSocialSecurityCheckbox.checked) {
+            const data = gatherFormData();
+            const gross = calculateCurrentPeriodPay(data).grossPay;
+            const ytd = parseFloat(document.getElementById('initialYtdSocialSecurity')?.value) || 0;
+            const val = estimateSocialSecurity(gross, ytd);
+            socialSecurityAmountInput.value = val.toFixed(2);
+            socialSecurityAmountInput.readOnly = true;
+            socialSecurityAmountInput.classList.add('auto-calculated-field');
+        } else {
+            socialSecurityAmountInput.readOnly = false;
+            socialSecurityAmountInput.classList.remove('auto-calculated-field');
+        }
+        updateLivePreview();
+    }
+
+    function handleMedicareAutoCalcChange() {
+        if (autoCalculateMedicareCheckbox.checked) {
+            const data = gatherFormData();
+            const gross = calculateCurrentPeriodPay(data).grossPay;
+            const val = estimateMedicare(gross);
+            medicareAmountInput.value = val.toFixed(2);
+            medicareAmountInput.readOnly = true;
+            medicareAmountInput.classList.add('auto-calculated-field');
+        } else {
+            medicareAmountInput.readOnly = false;
+            medicareAmountInput.classList.remove('auto-calculated-field');
+        }
+        updateLivePreview();
     }
 
 


### PR DESCRIPTION
## Summary
- define `SOCIAL_SECURITY_RATE` constant
- add handlers for Social Security and Medicare auto-calc options
- hook checkboxes to new handlers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68423b31cd8c832083f7b7232cabe5ef