### PR TITLE
Improve client-side form validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,8 @@
                     <div class="grid-col-2">
                         <div class="form-group">
                             <label for="desiredIncomeAmount">Desired Income Amount <span class="required-asterisk">*</span></label>
-                            <input type="number" id="desiredIncomeAmount" name="desiredIncomeAmount" step="0.01" min="0">
+                            <input type="number" id="desiredIncomeAmount" name="desiredIncomeAmount" step="0.01" required aria-required="true" aria-describedby="desiredIncomeAmountError" min="0">
+                            <span class="error-message" id="desiredIncomeAmountError"></span>
                         </div>
                         <div class="form-group">
                             <label id="desiredIncomeTypeLabel">Is this income amount:</label>
@@ -90,18 +91,20 @@
                         </div>
                         <div class="form-group">
                             <label for="desiredIncomePeriod">Income Period <span class="required-asterisk">*</span></label>
-                            <select id="desiredIncomePeriod" name="desiredIncomePeriod">
+                            <select id="desiredIncomePeriod" required aria-required="true" aria-describedby="desiredIncomePeriodError" name="desiredIncomePeriod">
                                 <option value="Annual" selected>Annual</option>
                                 <option value="Monthly">Monthly</option>
                                 <option value="Weekly">Weekly</option>
                             </select>
+                            <span class="error-message" id="desiredIncomePeriodError"></span>
                         </div>
                     </div>
                     <div class="form-group">
                         <label id="representAsLabel">Represent As <span class="required-asterisk">*</span></label>
                         <div class="radio-group" role="radiogroup" aria-labelledby="representAsLabel">
-                            <label><input type="radio" id="repAsSalaried" name="incomeRepresentationType" value="Salaried" checked> Salaried</label>
-                            <label><input type="radio" id="repAsHourly" name="incomeRepresentationType" value="Hourly"> Hourly</label>
+                            <label><input type="radio" aria-describedby="incomeRepresentationTypeError" id="repAsSalaried" name="incomeRepresentationType" value="Salaried" checked> Salaried</label>
+                            <label><input type="radio" aria-describedby="incomeRepresentationTypeError" id="repAsHourly" name="incomeRepresentationType" value="Hourly"> Hourly</label>
+                            <span class="error-message" id="incomeRepresentationTypeError"></span>
                         </div>
                     </div>
                     <div class="form-group" id="assumedHourlyHoursGroup" style="display:none;">
@@ -202,8 +205,8 @@
                         </div>
                     </div>
                     <div class="form-group">
-                    <label for="employeeSsn">Employee SSN (Last 4 Digits Only)</label>
-                        <input type="text" id="employeeSsn" name="employeeSsn" placeholder="1234" aria-describedby="employeeSsnError">
+                    <label for="employeeSsn">Employee SSN</label>
+                        <input type="text" id="employeeSsn" name="employeeSsn" placeholder="123-45-6789" aria-describedby="employeeSsnError">
                         <span class="error-message" id="employeeSsnError"></span>
                         <p class="info-text ssn-info">SSN is used for display on the paystub and is not stored by BuellDocs for this generator tool. See our <a href='privacy_policy.html'>Privacy Policy</a>.</p>
                     </div>
@@ -256,12 +259,12 @@
                         <div class="grid-col-3">
                             <div class="form-group">
                                 <label for="hourlyRate">Hourly Rate <span class="required-asterisk">*</span></label>
-                                <input type="number" id="hourlyRate" name="hourlyRate" step="0.01" min="0" value="0" aria-describedby="hourlyRateError">
+                                <input type="number" id="hourlyRate" name="hourlyRate" step="0.01" required aria-required="true" min="0" value="0" aria-describedby="hourlyRateError">
                                 <span class="error-message" id="hourlyRateError"></span>
                             </div>
                             <div class="form-group">
                                 <label for="regularHours">Regular Hours (per period) <span class="required-asterisk">*</span></label>
-                                <input type="number" id="regularHours" name="regularHours" step="0.01" min="0" value="0" aria-describedby="regularHoursError">
+                                <input type="number" id="regularHours" name="regularHours" step="0.01" required aria-required="true" min="0" value="0" aria-describedby="regularHoursError">
                                 <span class="error-message" id="regularHoursError"></span>
                             </div>
                             <div class="form-group">
@@ -276,12 +279,12 @@
                         <div class="grid-col-2">
                             <div class="form-group">
                                 <label for="annualSalary">Annual Salary <span class="required-asterisk">*</span></label>
-                                <input type="number" id="annualSalary" name="annualSalary" step="0.01" min="0" value="0" aria-describedby="annualSalaryError">
+                                <input type="number" id="annualSalary" name="annualSalary" step="0.01" required aria-required="true" min="0" value="0" aria-describedby="annualSalaryError">
                                 <span class="error-message" id="annualSalaryError"></span>
                             </div>
                             <div class="form-group">
                                 <label for="salariedPayFrequency">Pay Frequency (Salaried) <span class="required-asterisk">*</span></label>
-                                <select id="salariedPayFrequency" name="salariedPayFrequency" aria-describedby="salariedPayFrequencyError">
+                                <select id="salariedPayFrequency" required aria-required="true" name="salariedPayFrequency" aria-describedby="salariedPayFrequencyError">
                                     <option value="Weekly">Weekly</option>
                                     <option value="Bi-Weekly" selected>Bi-Weekly</option>
                                     <option value="Semi-Monthly">Semi-Monthly</option>

--- a/script.js
+++ b/script.js
@@ -1977,9 +1977,9 @@ document.addEventListener('DOMContentLoaded', () => {
             errorMessage = 'Please enter a valid email address.';
         }
 
-        if (isValid && field.name === 'employeeSsn' && value && !/^\d{4}$/.test(value)) {
+        if (isValid && field.name === "employeeSsn" && value && !/^\d{3}-?\d{2}-?\d{4}$/.test(value)) {
             isValid = false;
-            errorMessage = 'Please enter the last 4 digits of the SSN.';
+            errorMessage = "Please enter a valid SSN (123-45-6789 or 123456789).";
         }
 
         if (isValid && field.type === 'number' && parseFloat(value) < 0) {


### PR DESCRIPTION
## Summary
- require first-step income inputs and add error message placeholders
- add error span for income representation radio group
- update SSN field label and placeholder
- enforce required numeric fields
- validate SSN format in `script.js`

## Testing
- `node -c script.js` *(fails: Identifier 'autoCalculateFederalTaxCheckbox' has already been declared)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68423c202ab883208200ebbc32997371