### PR TITLE
Enhance form labels and tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
                     </div>
                      <div class="grid-col-2">
                         <div class="form-group">
-                            <label for="companyEin">Company EIN</label>
+                            <label for="companyEin">Company EIN <span class="tooltip-icon" tabindex="0" data-tooltip="Employer Identification Number (Federal Tax ID)">ℹ️</span></label>
                             <input type="text" id="companyEin" name="companyEin" aria-describedby="companyEinError">
                             <span class="error-message" id="companyEinError"></span>
                         </div>
@@ -202,7 +202,7 @@
                         </div>
                     </div>
                     <div class="form-group">
-                    <label for="employeeSsn">Employee SSN (Last 4 Digits Only)</label>
+                    <label for="employeeSsn">Employee SSN (XXX-XX-NNNN)</label>
                         <input type="text" id="employeeSsn" name="employeeSsn" placeholder="1234" aria-describedby="employeeSsnError">
                         <span class="error-message" id="employeeSsnError"></span>
                         <p class="info-text ssn-info">SSN is used for display on the paystub and is not stored by BuellDocs for this generator tool. See our <a href='privacy_policy.html'>Privacy Policy</a>.</p>
@@ -220,7 +220,7 @@
                 <!-- Pay Period & Dates (For First/Base Stub) -->
                 <section class="form-section-card form-section-minimized">
                     <h3>Pay Period & Dates (For First/Base Stub)</h3>
-                    <p class="info-text">For multiple stubs, subsequent dates auto-increment based on pay frequency.</p>
+                    <p class="info-text">For multiple stubs, later pay periods auto-increment based on the chosen frequency.</p>
                     <div class="grid-col-3">
                         <div class="form-group">
                             <label for="payPeriodStartDate">Pay Period Start Date <span class="required-asterisk">*</span></label>
@@ -255,7 +255,7 @@
                     <div id="hourlyFields">
                         <div class="grid-col-3">
                             <div class="form-group">
-                                <label for="hourlyRate">Hourly Rate <span class="required-asterisk">*</span></label>
+                                <label for="hourlyRate">Hourly Rate (per pay period) <span class="required-asterisk">*</span></label>
                                 <input type="number" id="hourlyRate" name="hourlyRate" step="0.01" min="0" value="0" aria-describedby="hourlyRateError">
                                 <span class="error-message" id="hourlyRateError"></span>
                             </div>
@@ -315,6 +315,7 @@
                 <!-- Taxes (Enter Amounts per Period - Simulation Only) -->
                 <section class="form-section-card form-section-minimized">
                     <h3>Taxes (Enter Amounts per Period - Simulation Only)</h3>
+                    <p class="info-text">All values are per pay period. Leave blank to auto-calc where available.</p>
                      <div class="grid-col-2">
                         <div class="form-group">
                             <label for="federalTaxAmount">Federal Tax Amount</label>
@@ -389,7 +390,7 @@
                             </label>
                         </div>
                         <div class="form-group">
-                            <label for="njUiHcWfAmount">NJ UI/HC/WF Amount</label>
+                            <label for="njUiHcWfAmount">NJ UI/HC/WF Amount <span class="tooltip-icon" tabindex="0" data-tooltip="New Jersey unemployment, health care and workforce tax">ℹ️</span></label>
                             <input type="number" id="njUiHcWfAmount" name="njUiHcWfAmount" step="0.01" min="0" value="0" aria-describedby="njUiHcWfAmountError">
                             <span class="error-message" id="njUiHcWfAmountError"></span>
                         </div>
@@ -434,10 +435,10 @@
                 <!-- Initial Year-to-Date (YTD) Figures -->
                 <section class="form-section-card form-section-minimized">
                     <h3>Initial Year-to-Date (YTD) Figures</h3>
-                    <p class="info-text">Enter YTD amounts *before* the first paystub in this batch. These accumulate for multiple stubs.</p>
+                    <p class="info-text">Enter totals from before this batch. They accumulate with each stub.</p>
                     <div class="grid-col-2">
                         <div class="form-group">
-                            <label for="initialYtdGrossPay">Initial YTD Gross Pay</label>
+                            <label for="initialYtdGrossPay">Initial YTD Gross Pay (before this batch) <span class="tooltip-icon" tabindex="0" data-tooltip="Totals accrued prior to generating these stubs">ℹ️</span></label>
                             <input type="number" id="initialYtdGrossPay" name="initialYtdGrossPay" step="0.01" min="0" value="0">
                         </div>
                         <div class="form-group">

--- a/styles.css
+++ b/styles.css
@@ -377,6 +377,60 @@ input.auto-calc-readonly[readonly] {
     margin-left: 2px;
 }
 
+/* Tooltip icon for help messages */
+.tooltip-icon {
+    color: var(--accent-gold);
+    margin-left: 4px;
+    cursor: help;
+    position: relative;
+    display: inline-block;
+    font-size: 0.9em;
+}
+.tooltip-icon:focus {
+    outline: 2px solid var(--accent-gold);
+    outline-offset: 2px;
+}
+.tooltip-icon::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 125%;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--accent-gold);
+    padding: 6px 8px;
+    border-radius: var(--border-radius-sm);
+    white-space: nowrap;
+    font-size: 12px;
+    opacity: 0;
+    visibility: hidden;
+    z-index: 1000;
+    transition: opacity 0.2s ease;
+    pointer-events: none;
+}
+.tooltip-icon::before {
+    content: '';
+    position: absolute;
+    bottom: 115%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 6px;
+    border-style: solid;
+    border-color: var(--bg-tertiary) transparent transparent transparent;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease;
+    z-index: 1000;
+}
+.tooltip-icon:hover::after,
+.tooltip-icon:focus::after,
+.tooltip-icon:hover::before,
+.tooltip-icon:focus::before {
+    opacity: 1;
+    visibility: visible;
+}
+
 .error-message {
     display: block;
     color: var(--error-color);


### PR DESCRIPTION
## Summary
- improve clarity of form labels in paystub generator
- add accessible help tooltips for complex fields
- refine instructional text for YTD and tax sections
- style tooltip popovers in dark theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68423c3d4f648320b0f78fb8f83e8df2