### PR TITLE
Improve input validation and preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
                     <div class="grid-col-2">
                         <div class="form-group">
                             <label for="companyName">Company Name <span class="required-asterisk">*</span></label>
-                            <input type="text" id="companyName" name="companyName" required aria-describedby="companyNameError" aria-required="true">
+                            <input type="text" id="companyName" name="companyName" required aria-describedby="companyNameError" aria-required="true" maxlength="100">
                             <span class="error-message" id="companyNameError"></span>
                         </div>
                         <div class="form-group">
@@ -144,30 +144,30 @@
                     </div>
                     <div class="form-group">
                         <label for="companyStreetAddress">Company Street Address</label>
-                        <input type="text" id="companyStreetAddress" name="companyStreetAddress" aria-describedby="companyStreetAddressError">
+                        <input type="text" id="companyStreetAddress" name="companyStreetAddress" aria-describedby="companyStreetAddressError" maxlength="100">
                         <span class="error-message" id="companyStreetAddressError"></span>
                     </div>
                     <div class="grid-col-3">
                         <div class="form-group">
                             <label for="companyCity">City</label>
-                            <input type="text" id="companyCity" name="companyCity" aria-describedby="companyCityError">
+                            <input type="text" id="companyCity" name="companyCity" aria-describedby="companyCityError" maxlength="50">
                             <span class="error-message" id="companyCityError"></span>
                         </div>
                         <div class="form-group">
                             <label for="companyState">State</label>
-                            <input type="text" id="companyState" name="companyState" aria-describedby="companyStateError">
+                            <input type="text" id="companyState" name="companyState" aria-describedby="companyStateError" maxlength="50">
                             <span class="error-message" id="companyStateError"></span>
                         </div>
                         <div class="form-group">
                             <label for="companyZip">ZIP Code</label>
-                            <input type="text" id="companyZip" name="companyZip" aria-describedby="companyZipError">
+                            <input type="text" id="companyZip" name="companyZip" aria-describedby="companyZipError" maxlength="10">
                             <span class="error-message" id="companyZipError"></span>
                         </div>
                     </div>
                      <div class="grid-col-2">
                         <div class="form-group">
                             <label for="companyEin">Company EIN <span class="tooltip-icon" tabindex="0" data-tooltip="Employer Identification Number (Federal Tax ID)">ℹ️</span></label>
-                            <input type="text" id="companyEin" name="companyEin" aria-describedby="companyEinError">
+                            <input type="text" id="companyEin" name="companyEin" aria-describedby="companyEinError" maxlength="10">
                             <span class="error-message" id="companyEinError"></span>
                         </div>
                         <div class="form-group">
@@ -187,28 +187,28 @@
                     <h3>Employee Information</h3>
                     <div class="form-group">
                         <label for="employeeFullName">Employee Full Name <span class="required-asterisk">*</span></label>
-                        <input type="text" id="employeeFullName" name="employeeFullName" required aria-describedby="employeeFullNameError" aria-required="true">
+                        <input type="text" id="employeeFullName" name="employeeFullName" required aria-describedby="employeeFullNameError" aria-required="true" maxlength="100">
                         <span class="error-message" id="employeeFullNameError"></span>
                     </div>
                     <div class="form-group">
                         <label for="employeeStreetAddress">Employee Street Address</label>
-                        <input type="text" id="employeeStreetAddress" name="employeeStreetAddress" aria-describedby="employeeStreetAddressError">
+                        <input type="text" id="employeeStreetAddress" name="employeeStreetAddress" aria-describedby="employeeStreetAddressError" maxlength="100">
                         <span class="error-message" id="employeeStreetAddressError"></span>
                     </div>
                     <div class="grid-col-3">
                         <div class="form-group">
                             <label for="employeeCity">City</label>
-                            <input type="text" id="employeeCity" name="employeeCity" aria-describedby="employeeCityError">
+                            <input type="text" id="employeeCity" name="employeeCity" aria-describedby="employeeCityError" maxlength="50">
                             <span class="error-message" id="employeeCityError"></span>
                         </div>
                         <div class="form-group">
                             <label for="employeeState">State</label>
-                            <input type="text" id="employeeState" name="employeeState" aria-describedby="employeeStateError">
+                            <input type="text" id="employeeState" name="employeeState" aria-describedby="employeeStateError" maxlength="50">
                             <span class="error-message" id="employeeStateError"></span>
                         </div>
                         <div class="form-group">
                             <label for="employeeZip">ZIP Code</label>
-                            <input type="text" id="employeeZip" name="employeeZip" aria-describedby="employeeZipError">
+                            <input type="text" id="employeeZip" name="employeeZip" aria-describedby="employeeZipError" maxlength="10">
                             <span class="error-message" id="employeeZipError"></span>
                         </div>
                     </div>

--- a/script.js
+++ b/script.js
@@ -1138,7 +1138,7 @@ document.addEventListener('DOMContentLoaded', () => {
             body: infoTableBody,
             startY: yPos,
             theme: 'plain',
-            styles: { fontSize: 9, cellPadding: 1.5 },
+            styles: { fontSize: 9, cellPadding: 1.5, overflow: 'linebreak' },
             columnStyles: {
                 0: { cellWidth: 25, fontStyle: 'bold' }, 1: { cellWidth: 'auto' },
                 2: { cellWidth: 25, fontStyle: 'bold' }, 3: { cellWidth: 'auto' },
@@ -1201,6 +1201,7 @@ document.addEventListener('DOMContentLoaded', () => {
             startY: yPos,
             theme: 'striped',
             headStyles: { fillColor: [50, 50, 50], textColor: 255 },
+            styles: { overflow: 'linebreak' },
             columnStyles: {
                 1: { halign: 'right' }, 2: { halign: 'right' },
                 3: { halign: 'right' }, 4: { halign: 'right' }
@@ -1234,6 +1235,7 @@ document.addEventListener('DOMContentLoaded', () => {
             startY: yPos,
             theme: 'striped',
             headStyles: { fillColor: [50, 50, 50], textColor: 255 },
+            styles: { overflow: 'linebreak' },
             columnStyles: {
                 1: { halign: 'right' }, 2: { halign: 'right' }
             },

--- a/styles.css
+++ b/styles.css
@@ -653,6 +653,15 @@ input.invalid, select.invalid, textarea.invalid {
     z-index: 2; /* Above watermark */
 }
 
+/* Prevent overly long text from breaking the preview layout */
+#paystubPreviewContent,
+#paystubPreviewContent td,
+#paystubPreviewContent th,
+#paystubPreviewContent div {
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+}
+
 .paystub-header-preview {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## Summary
- limit text field lengths to avoid layout overflow
- allow wrapping of long text in preview cells
- ensure jsPDF tables break long text when generating the PDF

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68424f52f1dc8320801057925a0fd363