### PR TITLE
Add accessibility controls for modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -735,7 +735,7 @@
     
 
     <!-- Notification Modal -->
-    <div id="notificationModal" class="modal" style="display:none;">
+    <div id="notificationModal" class="modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="notificationModalTitle">
         <div class="modal-content">
             <span class="close-modal-btn" id="closeNotificationModalBtn">&times;</span>
             <h2 id="notificationModalTitle">Notice</h2>


### PR DESCRIPTION
## Summary
- improve the notification modal markup with ARIA attributes
- add focus-trap logic and Escape key support for modals
- open and close payment/notification modals with new helpers

## Testing
- `node --check script.js` *(fails: SyntaxError: Unexpected token ')' )*


------
https://chatgpt.com/codex/tasks/task_e_68424fb2d3ac8320987d1efc8d0c88d3