### PR TITLE
Add remove logo feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,6 +177,7 @@
                                 <img id="companyLogoPreview" src="#" alt="Preview of Uploaded Company Logo" style="display:none;">
                                 <div class="logo-placeholder-text">Logo Preview</div>
                             </div>
+                            <button type="button" class="btn-remove-logo" data-target-input="companyLogo" data-target-preview="companyLogoPreview" data-target-placeholder="#companyLogoPreviewContainer .logo-placeholder-text">Remove</button>
                             <span class="error-message" id="companyLogoError"></span>
                         </div>
                     </div>
@@ -533,6 +534,7 @@
                                 <img id="payrollProviderLogoPreview" src="#" alt="Preview of Uploaded Payroll Provider Logo" style="display:none;">
                                 <div class="logo-placeholder-text">Logo Preview</div>
                             </div>
+                            <button type="button" class="btn-remove-logo" data-target-input="payrollProviderLogo" data-target-preview="payrollProviderLogoPreview" data-target-placeholder="#payrollProviderLogoPreviewContainer .logo-placeholder-text">Remove</button>
                             <span class="error-message" id="payrollProviderLogoError"></span>
                         </div>
                         <div class="form-group checkbox-group">

--- a/script.js
+++ b/script.js
@@ -318,6 +318,25 @@ document.addEventListener('DOMContentLoaded', () => {
     companyLogoInput.addEventListener('change', (e) => handleLogoUpload(e, companyLogoPreviewImg, companyLogoPlaceholder));
     payrollProviderLogoInput.addEventListener('change', (e) => handleLogoUpload(e, payrollProviderLogoPreviewImg, payrollProviderLogoPlaceholder));
 
+    // Handle Remove Logo Buttons
+    document.querySelectorAll('.btn-remove-logo').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const inputId = btn.dataset.targetInput;
+            const previewId = btn.dataset.targetPreview;
+            const placeholderSelector = btn.dataset.targetPlaceholder;
+            const inputEl = document.getElementById(inputId);
+            const previewEl = document.getElementById(previewId);
+            const placeholderEl = document.querySelector(placeholderSelector);
+            if (inputEl) inputEl.value = '';
+            if (previewEl) {
+                previewEl.src = '#';
+                previewEl.style.display = 'none';
+            }
+            if (placeholderEl) placeholderEl.style.display = 'block';
+            updateLivePreview();
+        });
+    });
+
     // Form input changes for live preview (debounced)
     const formInputs = paystubForm.querySelectorAll('input, select, textarea');
     formInputs.forEach(input => {

--- a/styles.css
+++ b/styles.css
@@ -549,6 +549,20 @@ input.invalid, select.invalid, textarea.invalid {
     text-align: center;
 }
 
+.btn-remove-logo {
+    background: none;
+    border: none;
+    color: var(--error-color);
+    cursor: pointer;
+    font-size: 12px;
+    margin-top: 5px;
+    padding: 0;
+}
+
+.btn-remove-logo:hover {
+    text-decoration: underline;
+}
+
 
 /* -------------------- */
 /* --- BUTTONS --- */


### PR DESCRIPTION
## Summary
- add 'Remove' buttons under company and payroll logo previews
- wire up remove buttons in JS to clear logo inputs and hide previews
- style new remove buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68424fc53014832096f8259844e74519