### PR TITLE
Add cross-field validation for named amount pairs

### DIFF
--- a/script.js
+++ b/script.js
@@ -1861,6 +1861,37 @@ document.addEventListener('DOMContentLoaded', () => {
                 isValid = false;
             }
         });
+
+        const otherDeductionAmount = parseFloat(document.getElementById('otherDeductionAmount').value);
+        const otherDeductionNameInput = document.getElementById('otherDeductionName');
+        if (otherDeductionNameInput) {
+            if (!isNaN(otherDeductionAmount) && otherDeductionAmount > 0) {
+                if (!otherDeductionNameInput.value.trim()) {
+                    showError(otherDeductionNameInput, 'Name required if amount is entered.');
+                    isValid = false;
+                } else {
+                    clearError(otherDeductionNameInput);
+                }
+            } else {
+                clearError(otherDeductionNameInput);
+            }
+        }
+
+        const miscEarningAmount = parseFloat(document.getElementById('miscEarningAmount').value);
+        const miscEarningNameInput = document.getElementById('miscEarningName');
+        if (miscEarningNameInput) {
+            if (!isNaN(miscEarningAmount) && miscEarningAmount > 0) {
+                if (!miscEarningNameInput.value.trim()) {
+                    showError(miscEarningNameInput, 'Name required if amount is entered.');
+                    isValid = false;
+                } else {
+                    clearError(miscEarningNameInput);
+                }
+            } else {
+                clearError(miscEarningNameInput);
+            }
+        }
+
         return isValid;
     }
 


### PR DESCRIPTION
## Summary
- enforce that `Other Deduction Name` is filled in when an `Other Deduction Amount` is provided
- enforce that `Miscellaneous Earning Name` is filled in when an `Miscellaneous Earning Amount` is provided

## Testing
- `node --check script.js` *(fails: SyntaxError at existing closing token)*

------
https://chatgpt.com/codex/tasks/task_e_68424fe744b4832084c9777b1ba94717