### PR TITLE
Add hints and validation for phone/EIN

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
                         </div>
                         <div class="form-group">
                             <label for="companyPhone">Company Phone</label>
-                            <input type="tel" id="companyPhone" name="companyPhone" aria-describedby="companyPhoneError">
+                            <input type="tel" id="companyPhone" name="companyPhone" placeholder="(###) ###-####" aria-describedby="companyPhoneError">
                             <span class="error-message" id="companyPhoneError"></span>
                         </div>
                     </div>
@@ -167,7 +167,7 @@
                      <div class="grid-col-2">
                         <div class="form-group">
                             <label for="companyEin">Company EIN <span class="tooltip-icon" tabindex="0" data-tooltip="Employer Identification Number (Federal Tax ID)">ℹ️</span></label>
-                            <input type="text" id="companyEin" name="companyEin" aria-describedby="companyEinError">
+                            <input type="text" id="companyEin" name="companyEin" placeholder="XX-XXXXXXX" aria-describedby="companyEinError">
                             <span class="error-message" id="companyEinError"></span>
                         </div>
                         <div class="form-group">

--- a/script.js
+++ b/script.js
@@ -1906,6 +1906,25 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
 
+        // Optional pattern hints
+        if (field.id === 'companyPhone') {
+            if (value && !/^[\d\s()+-]{7,20}$/.test(value)) {
+                showError(field, 'Format e.g. (555) 123-4567');
+            } else {
+                clearError(field);
+            }
+            return true;
+        }
+
+        if (field.id === 'companyEin') {
+            if (value && !/^\d{2}-?\d{7}$/.test(value)) {
+                showError(field, 'Format e.g. 12-3456789');
+            } else {
+                clearError(field);
+            }
+            return true;
+        }
+
 
         if (!isValid) {
             showError(field, errorMessage);


### PR DESCRIPTION
## Summary
- add placeholder hints for optional company phone and EIN fields
- warn if phone/EIN formats look wrong without blocking submission

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842504c6708832090bef8c4a72fbabf