### PR TITLE
Fix duplicate validation modal call

### DIFF
--- a/script.js
+++ b/script.js
@@ -974,8 +974,8 @@ document.addEventListener('DOMContentLoaded', () => {
             showSummaryError('Please review the highlighted fields below.');
             const firstError = paystubForm.querySelector('.invalid');
             if (firstError) firstError.focus();
+            // Notify the user once about the validation issue
             showNotificationModal('Validation Error', 'Please fix the errors in the form before generating the PDF.'); // Replace with custom modal later
-            showNotificationModal('Validation Error', 'Please fix the errors in the form before generating the PDF.');
             return;
         }
 


### PR DESCRIPTION
## Summary
- remove duplicate `showNotificationModal` invocation in PDF generation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842505b2b2c83209a2c6d4f80ee8ace