### PR TITLE
Fix net income note clearing

### DIFF
--- a/script.js
+++ b/script.js
@@ -40,10 +40,23 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    [desiredIncomeAmountInput, desiredIncomePeriodSelect, assumedHourlyRegularHoursInput,
+    function clearNetIncomeAdjustmentNote() {
+        if (netIncomeAdjustmentNote) {
+            netIncomeAdjustmentNote.textContent = '';
+            netIncomeAdjustmentNote.style.display = 'none';
+        }
+    }
+
+[desiredIncomeAmountInput, desiredIncomePeriodSelect, assumedHourlyRegularHoursInput,
      isForNjEmploymentCheckbox, ...incomeRepresentationRadios, ...desiredIncomeTypeRadios].forEach(el => {
         el.addEventListener('input', enablePopulateBtn);
         el.addEventListener('change', enablePopulateBtn);
+    });
+
+    // Clear net-to-gross note only when the desired amount or type is altered
+    desiredIncomeAmountInput.addEventListener('input', clearNetIncomeAdjustmentNote);
+    desiredIncomeTypeRadios.forEach(radio => {
+        radio.addEventListener('change', clearNetIncomeAdjustmentNote);
     });
 
     // Logo Preview Elements


### PR DESCRIPTION
## Summary
- keep `#netIncomeAdjustmentNote` visible until desired income fields change or a new calculation starts

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68425080f56c83208acc0812a73e512f