### PR TITLE
Fix stub preview indicator bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -860,8 +860,6 @@ document.addEventListener('DOMContentLoaded', () => {
         // Update stub indicator
         livePreviewStubIndicator.textContent = `(Previewing Stub: ${currentPreviewStubIndex + 1} of ${numStubs})`;
         livePreviewStubXofY.textContent = `Stub ${currentPreviewStubIndex + 1} of ${numStubs}`;
-        livePreviewStubIndicator.textContent = `(Previewing Stub: ${currentPreviewStubIndex + 1} of ${totalStubs})`;
-        livePreviewStubXofY.textContent = `Stub ${currentPreviewStubIndex + 1} of ${totalStubs}`;
 
         // Company Info
         livePreviewCompanyName.textContent = displayDataForStub.companyName || 'Your Company Name';


### PR DESCRIPTION
## Summary
- update stub indicator text in `updateLivePreview`

## Testing
- `node --check script.js` *(fails: Unexpected token)

------
https://chatgpt.com/codex/tasks/task_e_68425097d1a083208c968801a6fe05b0