### PR TITLE
Improve feedback for draft save/load

### DIFF
--- a/script.js
+++ b/script.js
@@ -1399,6 +1399,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const originalText = saveDraftBtn.textContent;
             saveDraftBtn.textContent = 'Draft Saved!';
             setTimeout(() => { saveDraftBtn.textContent = originalText; }, 1500);
+            showNotificationModal('Draft Saved', 'Your current form progress has been saved to this browser.');
         } catch (e) {
             console.error('Failed to save draft', e);
         }
@@ -1468,9 +1469,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 setTimeout(() => {
                     loadDraftBtn.textContent = originalText;
                 }, 1500);
-            } else {
-                showNotificationModal('No Draft Found', 'There is no saved draft to load.');
             }
+            showNotificationModal('No Draft Found', 'No saved draft was found in this browser.');
             return;
         }
 
@@ -1521,6 +1521,7 @@ document.addEventListener('DOMContentLoaded', () => {
         toggleEmploymentFields();
         updateHourlyPayFrequencyVisibility();
         updateLivePreview();
+        showNotificationModal('Draft Loaded', 'Your previously saved draft has been loaded into the form.');
     }
 
     function autoPopulateFromDesiredIncome() {


### PR DESCRIPTION
## Summary
- notify user when draft is saved to local storage
- show confirmation modal on draft load
- show alert if draft not found

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842519a2b2c8320ba2fe2f4cb3e0561