### PR TITLE
Clarify payment workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -720,14 +720,14 @@
 
             <div id="modalOrderSuccessMessage" style="display:none;">
                 <h3>Thank You!</h3>
-                <p>Your (simulated) order details have been noted. To receive your final, clean paystub(s) (without the 'PREVIEW' watermark or novelty disclaimer), please manually email a screenshot of your payment receipt AND the following information to <strong id="supportEmailAddress">buellschool@gmail.com</strong>:</p>
+                <p><strong>Payment Processed (Simulated)!</strong> Your final, clean paystub(s) will be generated and emailed to <strong id="successUserEmailInline"></strong> typically <strong id="turnaroundTime">within 24 hours</strong> after your manual payment is confirmed by our team.</p>
+                <p>To ensure your order is processed correctly, please email a screenshot of your payment receipt and the following information to <strong id="supportEmailAddress">buellschool@gmail.com</strong>:</p>
                 <ul>
                     <li>Email used on form: <strong id="successUserEmail"></strong></li>
                     <li>Cash App/Payment Transaction ID entered: <strong id="successTxId"></strong></li>
                     <li>Number of Stubs Requested: <strong id="successNumStubs"></strong></li>
                     <li>Additional Notes/Custom Requests: <strong id="successUserNotes">None provided</strong></li>
                 </ul>
-                <p>(This manual step ensures your order is processed correctly after payment verification. You will receive your document(s) via email typically <strong id="turnaroundTime">within 24 hours</strong>.)</p>
                 <button id="closeSuccessMessageBtn" class="btn btn-secondary">Close</button>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -137,6 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const closeNotificationModalBtn = document.getElementById("closeNotificationModalBtn");
     // Success Message Placeholders
     const successUserEmailSpan = document.getElementById('successUserEmail');
+    const successUserEmailInlineSpan = document.getElementById('successUserEmailInline');
     const successTxIdSpan = document.getElementById('successTxId');
     const successNumStubsSpan = document.getElementById('successNumStubs');
     const successUserNotesSpan = document.getElementById('successUserNotes');
@@ -1322,6 +1323,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const formData = gatherFormData();
         successUserEmailSpan.textContent = formData.userEmail;
+        successUserEmailInlineSpan.textContent = formData.userEmail;
         successTxIdSpan.textContent = txId;
         successNumStubsSpan.textContent = numPaystubsSelect.value;
         successUserNotesSpan.textContent = formData.userNotes || 'None provided';


### PR DESCRIPTION
## Summary
- clarify the success message in payment modal
- expose user's email in success message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684251c83d788320adec9312f63e8ced