### PR TITLE
Improve tooltip accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
                     </div>
                      <div class="grid-col-2">
                         <div class="form-group">
-                            <label for="companyEin">Company EIN <span class="tooltip-icon" tabindex="0" data-tooltip="Employer Identification Number (Federal Tax ID)">ℹ️</span></label>
+                            <label for="companyEin">Company EIN <span class="tooltip-icon" tabindex="0" data-tooltip="Employer Identification Number (Federal Tax ID)" aria-describedby="einTooltipText">ℹ️</span><span id="einTooltipText" class="visually-hidden">Employer Identification Number (Federal Tax ID)</span></label>
                             <input type="text" id="companyEin" name="companyEin" aria-describedby="companyEinError">
                             <span class="error-message" id="companyEinError"></span>
                         </div>
@@ -420,7 +420,7 @@
                             </label>
                         </div>
                         <div class="form-group">
-                            <label for="njUiHcWfAmount">NJ UI/HC/WF Amount <span class="tooltip-icon" tabindex="0" data-tooltip="New Jersey unemployment, health care and workforce tax">ℹ️</span></label>
+                            <label for="njUiHcWfAmount">NJ UI/HC/WF Amount <span class="tooltip-icon" tabindex="0" data-tooltip="New Jersey unemployment, health care and workforce tax" aria-describedby="njUiHcWfTooltipText">ℹ️</span><span id="njUiHcWfTooltipText" class="visually-hidden">New Jersey unemployment, health care and workforce tax</span></label>
                             <input type="number" id="njUiHcWfAmount" name="njUiHcWfAmount" step="0.01" min="0" value="0" aria-describedby="njUiHcWfAmountError">
                             <span class="error-message" id="njUiHcWfAmountError"></span>
                         </div>
@@ -475,7 +475,7 @@
                     <p class="info-text">Enter totals from before this batch. They accumulate with each stub.</p>
                     <div class="grid-col-2">
                         <div class="form-group">
-                            <label for="initialYtdGrossPay">Initial YTD Gross Pay (before this batch) <span class="tooltip-icon" tabindex="0" data-tooltip="Totals accrued prior to generating these stubs">ℹ️</span></label>
+                            <label for="initialYtdGrossPay">Initial YTD Gross Pay (before this batch) <span class="tooltip-icon" tabindex="0" data-tooltip="Totals accrued prior to generating these stubs" aria-describedby="initialYtdGrossPayTooltipText">ℹ️</span><span id="initialYtdGrossPayTooltipText" class="visually-hidden">Totals accrued prior to generating these stubs</span></label>
                             <input type="number" id="initialYtdGrossPay" name="initialYtdGrossPay" step="0.01" min="0" value="0">
                         </div>
                         <div class="form-group">

--- a/script.js
+++ b/script.js
@@ -120,6 +120,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const sharePdfEmailLink = document.getElementById('sharePdfEmail');
     const sharePdfInstructions = document.getElementById('sharePdfInstructions');
 
+    // Ensure tooltip text is accessible to screen readers
+    document.querySelectorAll('.tooltip-icon[data-tooltip]').forEach((icon, idx) => {
+        if (!icon.hasAttribute('aria-describedby')) {
+            const tooltipId = `tooltipText${idx}`;
+            const hiddenSpan = document.createElement('span');
+            hiddenSpan.id = tooltipId;
+            hiddenSpan.className = 'visually-hidden';
+            hiddenSpan.textContent = icon.getAttribute('data-tooltip');
+            icon.setAttribute('aria-describedby', tooltipId);
+            icon.after(hiddenSpan);
+        }
+    });
+
     // Modal Elements
     const paymentModal = document.getElementById('paymentModal');
     const closePaymentModalBtn = document.getElementById('closePaymentModalBtn');

--- a/styles.css
+++ b/styles.css
@@ -383,6 +383,19 @@ input.auto-calc-readonly[readonly] {
     margin-left: 2px;
 }
 
+/* Screen reader only text */
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* Tooltip icon for help messages */
 .tooltip-icon {
     color: var(--accent-gold);


### PR DESCRIPTION
## Summary
- expose tooltip text to assistive tech with hidden spans
- programmatically add screen reader support for existing tooltips
- add `.visually-hidden` helper class

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684252570f8883209f166aa4cb8dc0f9