### PR TITLE
Add live pay calculation updates

### DIFF
--- a/script.js
+++ b/script.js
@@ -465,6 +465,12 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
+    const debouncedTotalsUpdate = debounce(updatePaystubTotals, 300);
+    formInputs.forEach(input => {
+        input.addEventListener('input', debouncedTotalsUpdate);
+        input.addEventListener('change', debouncedTotalsUpdate);
+    });
+
     if (nextStubBtn && prevStubBtn) {
         nextStubBtn.addEventListener('click', () => {
             const numStubs = parseInt(numPaystubsSelect.value) || 1;
@@ -488,6 +494,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     // Initial preview update
     updateLivePreview();
+    updatePaystubTotals();
 
     const initialNumStubs = parseInt(numPaystubsSelect.value) || 1;
     if (previewNavControls) previewNavControls.style.display = initialNumStubs > 1 ? 'block' : 'none';
@@ -1114,6 +1121,25 @@ document.addEventListener('DOMContentLoaded', () => {
         // For responsive table attributes
         row.cells[1].setAttribute('data-label', 'Current');
         row.cells[2].setAttribute('data-label', 'YTD');
+    }
+
+    // Basic pay calculations used for quick live updates
+    function calculateGrossPay() {
+        return calculateCurrentPeriodPay(gatherFormData()).grossPay;
+    }
+
+    function calculateTotalDeductions() {
+        return calculateCurrentPeriodPay(gatherFormData()).totalDeductions;
+    }
+
+    function calculateNetPay() {
+        return calculateCurrentPeriodPay(gatherFormData()).netPay;
+    }
+
+    function updatePaystubTotals() {
+        livePreviewGrossPay.textContent = formatCurrency(calculateGrossPay());
+        livePreviewTotalDeductions.textContent = formatCurrency(calculateTotalDeductions());
+        livePreviewNetPay.textContent = formatCurrency(calculateNetPay());
     }
 
 


### PR DESCRIPTION
## Summary
- calculate gross pay, deductions, and net pay from current form data
- update paystub totals automatically on input changes
- refresh totals on initial preview

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684263a5cd508320ad27e8a2f41971bc