### PR TITLE
Implement SS and Medicare auto calculations

### DIFF
--- a/script.js
+++ b/script.js
@@ -377,6 +377,18 @@ document.addEventListener('DOMContentLoaded', () => {
         ]
     };
 
+    // --- Payroll Tax Calculation Helpers --- //
+    function calculateSocialSecurityDeduction(grossPay, ytdGross = 0) {
+        const remaining = SOCIAL_SECURITY_WAGE_LIMIT_2024 - ytdGross;
+        if (remaining <= 0) return 0;
+        const taxable = Math.min(grossPay, remaining);
+        return taxable * SOCIAL_SECURITY_RATE;
+    }
+
+    function calculateMedicareDeduction(grossPay) {
+        return grossPay * MEDICARE_RATE;
+    }
+
     // Simplified federal tax brackets for quick estimation
     const FEDERAL_TAX_BRACKETS = {
         'Single': [
@@ -1859,7 +1871,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         if (autoCalculateSocialSecurityCheckbox && autoCalculateSocialSecurityCheckbox.checked) {
-            const val = estimateSocialSecurity(gross, ytdGross);
+            const val = calculateSocialSecurityDeduction(gross, ytdGross);
             socialSecurityAmountInput.value = val.toFixed(2);
             socialSecurityAmountInput.readOnly = true;
             socialSecurityAmountInput.classList.add('auto-calculated-field');
@@ -1869,7 +1881,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         if (autoCalculateMedicareCheckbox && autoCalculateMedicareCheckbox.checked) {
-            const val = estimateMedicare(gross);
+            const val = calculateMedicareDeduction(gross);
             medicareAmountInput.value = val.toFixed(2);
             medicareAmountInput.readOnly = true;
             medicareAmountInput.classList.add('auto-calculated-field');
@@ -1952,7 +1964,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const data = gatherFormData();
             const gross = calculateCurrentPeriodPay(data).grossPay;
             const ytd = parseFloat(document.getElementById('initialYtdSocialSecurity')?.value) || 0;
-            const val = estimateSocialSecurity(gross, ytd);
+            const val = calculateSocialSecurityDeduction(gross, ytd);
             socialSecurityAmountInput.value = val.toFixed(2);
             socialSecurityAmountInput.readOnly = true;
             socialSecurityAmountInput.classList.add('auto-calculated-field');
@@ -1967,7 +1979,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (autoCalculateMedicareCheckbox.checked) {
             const data = gatherFormData();
             const gross = calculateCurrentPeriodPay(data).grossPay;
-            const val = estimateMedicare(gross);
+            const val = calculateMedicareDeduction(gross);
             medicareAmountInput.value = val.toFixed(2);
             medicareAmountInput.readOnly = true;
             medicareAmountInput.classList.add('auto-calculated-field');


### PR DESCRIPTION
## Summary
- add helper functions to compute Social Security and Medicare taxes
- use helpers when auto-calc fields are toggled

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684263e3268083208ae90a1557f9e969