### PR TITLE
Implement automatic Social Security and Medicare calculations

### DIFF
--- a/script.js
+++ b/script.js
@@ -355,6 +355,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const NJ_UIHCWF_RATE = 0.000425; // 0.0425%
     const NJ_UIHCWF_WAGE_LIMIT = 42300;
 
+    function calculateSocialSecurity(grossPay) {
+        return parseFloat((grossPay * SOCIAL_SECURITY_RATE).toFixed(2));
+    }
+
+    function calculateMedicare(grossPay) {
+        return parseFloat((grossPay * MEDICARE_RATE).toFixed(2));
+    }
+
     const NJ_TAX_BRACKETS_2024 = {
         'Single': [
             { limit: 20000, rate: 0.014 },
@@ -1859,7 +1867,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         if (autoCalculateSocialSecurityCheckbox && autoCalculateSocialSecurityCheckbox.checked) {
-            const val = estimateSocialSecurity(gross, ytdGross);
+            const val = calculateSocialSecurity(gross);
             socialSecurityAmountInput.value = val.toFixed(2);
             socialSecurityAmountInput.readOnly = true;
             socialSecurityAmountInput.classList.add('auto-calculated-field');
@@ -1869,7 +1877,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         if (autoCalculateMedicareCheckbox && autoCalculateMedicareCheckbox.checked) {
-            const val = estimateMedicare(gross);
+            const val = calculateMedicare(gross);
             medicareAmountInput.value = val.toFixed(2);
             medicareAmountInput.readOnly = true;
             medicareAmountInput.classList.add('auto-calculated-field');
@@ -1951,8 +1959,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (autoCalculateSocialSecurityCheckbox.checked) {
             const data = gatherFormData();
             const gross = calculateCurrentPeriodPay(data).grossPay;
-            const ytd = parseFloat(document.getElementById('initialYtdSocialSecurity')?.value) || 0;
-            const val = estimateSocialSecurity(gross, ytd);
+            const val = calculateSocialSecurity(gross);
             socialSecurityAmountInput.value = val.toFixed(2);
             socialSecurityAmountInput.readOnly = true;
             socialSecurityAmountInput.classList.add('auto-calculated-field');
@@ -1967,7 +1974,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (autoCalculateMedicareCheckbox.checked) {
             const data = gatherFormData();
             const gross = calculateCurrentPeriodPay(data).grossPay;
-            const val = estimateMedicare(gross);
+            const val = calculateMedicare(gross);
             medicareAmountInput.value = val.toFixed(2);
             medicareAmountInput.readOnly = true;
             medicareAmountInput.classList.add('auto-calculated-field');


### PR DESCRIPTION
## Summary
- add helper methods `calculateSocialSecurity` and `calculateMedicare`
- populate deduction fields using these helpers when auto-calc is enabled

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684263b49b2c8320957581e1482e545d