### PR TITLE
Add stub preview navigation functions

### DIFF
--- a/script.js
+++ b/script.js
@@ -406,15 +406,37 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     populateDetailsBtn.addEventListener('click', autoPopulateFromDesiredIncome);
 
+    // --- Preview Navigation Helpers --- //
+    function updatePreviewNavButtons() {
+        const numStubs = parseInt(numPaystubsSelect.value) || 1;
+        if (previewNavControls) previewNavControls.style.display = numStubs > 1 ? 'block' : 'none';
+        if (prevStubBtn) prevStubBtn.disabled = currentPreviewStubIndex === 0;
+        if (nextStubBtn) nextStubBtn.disabled = currentPreviewStubIndex >= numStubs - 1;
+    }
+
+    function goToNextStub() {
+        const numStubs = parseInt(numPaystubsSelect.value) || 1;
+        if (currentPreviewStubIndex < numStubs - 1) {
+            currentPreviewStubIndex++;
+            updateLivePreview();
+        }
+        updatePreviewNavButtons();
+    }
+
+    function goToPreviousStub() {
+        if (currentPreviewStubIndex > 0) {
+            currentPreviewStubIndex--;
+            updateLivePreview();
+        }
+        updatePreviewNavButtons();
+    }
+
     // Update Hourly Pay Frequency Visibility and preview navigation when number of stubs changes
     numPaystubsSelect.addEventListener('change', () => {
         updateHourlyPayFrequencyVisibility();
         currentPreviewStubIndex = 0;
-        const numStubs = parseInt(numPaystubsSelect.value) || 1;
-        if (previewNavControls) previewNavControls.style.display = numStubs > 1 ? 'block' : 'none';
-        if (prevStubBtn) prevStubBtn.disabled = true;
-        if (nextStubBtn) nextStubBtn.disabled = numStubs <= 1;
         updateLivePreview();
+        updatePreviewNavButtons();
     });
     // Also trigger on employment type change
     employmentTypeRadios.forEach(radio => radio.addEventListener('change', updateHourlyPayFrequencyVisibility));
@@ -466,33 +488,15 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     if (nextStubBtn && prevStubBtn) {
-        nextStubBtn.addEventListener('click', () => {
-            const numStubs = parseInt(numPaystubsSelect.value) || 1;
-            if (currentPreviewStubIndex < numStubs - 1) {
-                currentPreviewStubIndex++;
-                updateLivePreview();
-            }
-            prevStubBtn.disabled = currentPreviewStubIndex === 0;
-            nextStubBtn.disabled = currentPreviewStubIndex >= numStubs - 1;
-        });
-
-        prevStubBtn.addEventListener('click', () => {
-            const numStubs = parseInt(numPaystubsSelect.value) || 1;
-            if (currentPreviewStubIndex > 0) {
-                currentPreviewStubIndex--;
-                updateLivePreview();
-            }
-            prevStubBtn.disabled = currentPreviewStubIndex === 0;
-            nextStubBtn.disabled = currentPreviewStubIndex >= numStubs - 1;
-        });
+        nextStubBtn.addEventListener('click', goToNextStub);
+        prevStubBtn.addEventListener('click', goToPreviousStub);
     }
     // Initial preview update
     updateLivePreview();
 
     const initialNumStubs = parseInt(numPaystubsSelect.value) || 1;
-    if (previewNavControls) previewNavControls.style.display = initialNumStubs > 1 ? 'block' : 'none';
-    if (prevStubBtn) prevStubBtn.disabled = true;
-    if (nextStubBtn) nextStubBtn.disabled = initialNumStubs <= 1;
+    currentPreviewStubIndex = 0;
+    updatePreviewNavButtons();
 
 
     // Sidebar Button Actions
@@ -1085,10 +1089,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         livePreviewVoidedCheckContainer.style.display = displayDataForStub.includeVoidedCheck ? 'block' : 'none';
 
-        if (prevStubBtn && nextStubBtn) {
-            prevStubBtn.disabled = currentPreviewStubIndex === 0;
-            nextStubBtn.disabled = currentPreviewStubIndex >= numStubs - 1;
-        }
+        updatePreviewNavButtons();
     }
 
     function addEarningRow(description, hours, rate, current, ytd) {


### PR DESCRIPTION
## Summary
- manage navigation buttons for multiple preview paystubs
- create `goToNextStub`, `goToPreviousStub` and `updatePreviewNavButtons`
- hook buttons and stub count changes to these functions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684263ebf5808320844c508a7771b6f4