### PR TITLE
Unify about page styling

### DIFF
--- a/about_buelldocs.html
+++ b/about_buelldocs.html
@@ -5,81 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About BuellDocs | The Architect</title>
     <link rel="stylesheet" href="styles.css">
-    <style>
-    .main-content {
-        padding-top: calc(var(--header-height) + 30px);
-        padding-left: 30px;
-        padding-right: 30px;
-        max-width: 900px;
-        margin: 0 auto;
-    }
-
-    .page-section {
-        margin-bottom: 40px;
-    }
-
-    .content-card {
-        background-color: var(--bg-secondary);
-        border: 1px solid var(--border-color);
-        border-radius: var(--border-radius-md);
-        padding: 25px;
-        box-shadow: 0 4px 15px rgba(0,0,0,0.1);
-    }
-
-    h1, h2, h3 {
-        font-weight: 500;
-        text-transform: uppercase;
-        letter-spacing: var(--letter-spacing-header);
-    }
-
-    h1 { font-size: 28px; margin-bottom: 15px; }
-    h2 { font-size: 24px; margin-bottom: 15px; color: var(--accent-gold); }
-    h3 { font-size: 20px; margin-bottom: 10px; color: var(--accent-gold); }
-
-    p { color: var(--text-secondary); margin-bottom: 15px; }
-
-    .terminal-card {
-        background-color: #111;
-        border-radius: var(--border-radius-md);
-        padding: 20px;
-        font-family: "Courier New", Courier, monospace;
-        color: var(--text-primary);
-        border: 1px solid var(--border-color);
-        position: relative;
-    }
-
-    .terminal-controls {
-        position: absolute;
-        top: 10px;
-        left: 10px;
-        display: flex;
-        gap: 6px;
-    }
-
-    .terminal-controls span {
-        width: 10px;
-        height: 10px;
-        border-radius: 50%;
-        display: inline-block;
-    }
-
-    .red { background-color: #ff5f56; }
-    .yellow { background-color: #ffbd2e; }
-    .green { background-color: #27c93f; }
-
-    footer {
-        padding: 20px 30px;
-        border-top: 1px solid var(--border-color-light);
-        text-align: center;
-        color: var(--text-tertiary);
-        font-size: 14px;
-    }
-
-    @media (max-width: 768px) {
-        .header-nav .nav-link { margin-left: 15px; font-size: 14px; }
-        .main-content { padding-left: 15px; padding-right: 15px; }
-    }
-</style>
 </head>
 <!-- TODO: For any future large images added to this page, use the HTML loading="lazy" attribute, e.g., <img src="image.jpg" loading="lazy" alt="..."> -->
 <body>
@@ -89,7 +14,7 @@
     <header class="app-header">
         <div class="logo-container">
             <span class="logo-text">BUELLDOCS</span>
-            <span class="header-tagline">Secure Document Services</span>
+            <span class="header-tagline">Client Dashboard</span>
         </div>
         <nav class="header-nav">
             <a href="index.html" class="nav-link">Client Dashboard</a>
@@ -98,7 +23,7 @@
         <a class="btn btn-secondary header-contact-btn" href="mailto:buellschool@gmail.com">Contact Us</a>
     </header>
 
-    <main class="main-content">
+    <main class="main-content centered-main">
         <section class="about-hero page-section content-card">
             <h1>Meet <span style="color: var(--accent-gold);">The Architect</span></h1>
             <p>At 33, I've made it my mission to become the ultimate fixer—the Michael Clayton of documentation. After years honing my craft within rigid corporate structures, I redirected my skills to serve those who truly need them: you.</p>

--- a/styles.css
+++ b/styles.css
@@ -1164,3 +1164,64 @@ input.invalid, select.invalid, textarea.invalid {
         margin-bottom: 18px;
     }
 }
+
+/* --- GENERIC PAGE STYLES --- */
+.centered-main {
+    padding-top: calc(var(--header-height) + 40px);
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.page-section {
+    margin-bottom: 40px;
+}
+
+.content-card {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-md);
+    padding: 25px;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+}
+
+.terminal-card {
+    background-color: #111;
+    border-radius: var(--border-radius-md);
+    padding: 20px;
+    font-family: "Courier New", Courier, monospace;
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    position: relative;
+}
+
+.terminal-controls {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    display: flex;
+    gap: 6px;
+}
+
+.terminal-controls span {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.red { background-color: #ff5f56; }
+.yellow { background-color: #ffbd2e; }
+.green { background-color: #27c93f; }
+
+footer {
+    padding: 20px 30px;
+    border-top: 1px solid var(--border-color-light);
+    text-align: center;
+    color: var(--text-tertiary);
+    font-size: 14px;
+}
+
+@media (max-width: 768px) {
+    .centered-main { padding-left: 15px; padding-right: 15px; }
+}
+


### PR DESCRIPTION
## Summary
- remove inline styles from About page
- update About header tagline to match client dashboard
- reuse global `.centered-main`, `.content-card`, and related utilities
- add shared page styles in `styles.css`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68426b8b8568832099a6aed3f6af0088