### PR TITLE
Fix sidebar form overlap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -163,8 +163,8 @@ label, input, select, textarea, button {
 /* -------------------- */
 .main-wrapper {
     display: flex;
+    align-items: flex-start; /* Prevent sidebar height from stretching content */
     padding-top: var(--header-height); /* Account for fixed header */
-    min-height: calc(100vh - var(--header-height));
 }
 
 /* -------------------- */
@@ -208,7 +208,7 @@ label, input, select, textarea, button {
 .main-content {
     flex: 1;
     padding: 40px;
-    overflow-y: auto; /* Allows main content to scroll independently if needed */
+    /* Let page scroll naturally instead of independent scrolling */
 }
 
 .hero-section {


### PR DESCRIPTION
## Summary
- prevent `.main-wrapper` from stretching the main content height
- let main page scroll naturally

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68426b80c28083209891213db74bac1d