### PR TITLE
Unify About page styling

### DIFF
--- a/about_buelldocs.html
+++ b/about_buelldocs.html
@@ -5,81 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About BuellDocs | The Architect</title>
     <link rel="stylesheet" href="styles.css">
-    <style>
-    .main-content {
-        padding-top: calc(var(--header-height) + 30px);
-        padding-left: 30px;
-        padding-right: 30px;
-        max-width: 900px;
-        margin: 0 auto;
-    }
-
-    .page-section {
-        margin-bottom: 40px;
-    }
-
-    .content-card {
-        background-color: var(--bg-secondary);
-        border: 1px solid var(--border-color);
-        border-radius: var(--border-radius-md);
-        padding: 25px;
-        box-shadow: 0 4px 15px rgba(0,0,0,0.1);
-    }
-
-    h1, h2, h3 {
-        font-weight: 500;
-        text-transform: uppercase;
-        letter-spacing: var(--letter-spacing-header);
-    }
-
-    h1 { font-size: 28px; margin-bottom: 15px; }
-    h2 { font-size: 24px; margin-bottom: 15px; color: var(--accent-gold); }
-    h3 { font-size: 20px; margin-bottom: 10px; color: var(--accent-gold); }
-
-    p { color: var(--text-secondary); margin-bottom: 15px; }
-
-    .terminal-card {
-        background-color: #111;
-        border-radius: var(--border-radius-md);
-        padding: 20px;
-        font-family: "Courier New", Courier, monospace;
-        color: var(--text-primary);
-        border: 1px solid var(--border-color);
-        position: relative;
-    }
-
-    .terminal-controls {
-        position: absolute;
-        top: 10px;
-        left: 10px;
-        display: flex;
-        gap: 6px;
-    }
-
-    .terminal-controls span {
-        width: 10px;
-        height: 10px;
-        border-radius: 50%;
-        display: inline-block;
-    }
-
-    .red { background-color: #ff5f56; }
-    .yellow { background-color: #ffbd2e; }
-    .green { background-color: #27c93f; }
-
-    footer {
-        padding: 20px 30px;
-        border-top: 1px solid var(--border-color-light);
-        text-align: center;
-        color: var(--text-tertiary);
-        font-size: 14px;
-    }
-
-    @media (max-width: 768px) {
-        .header-nav .nav-link { margin-left: 15px; font-size: 14px; }
-        .main-content { padding-left: 15px; padding-right: 15px; }
-    }
-</style>
 </head>
 <!-- TODO: For any future large images added to this page, use the HTML loading="lazy" attribute, e.g., <img src="image.jpg" loading="lazy" alt="..."> -->
 <body>
@@ -98,7 +23,7 @@
         <a class="btn btn-secondary header-contact-btn" href="mailto:buellschool@gmail.com">Contact Us</a>
     </header>
 
-    <main class="main-content">
+    <main class="main-content about-main">
         <section class="about-hero page-section content-card">
             <h1>Meet <span style="color: var(--accent-gold);">The Architect</span></h1>
             <p>At 33, I've made it my mission to become the ultimate fixer—the Michael Clayton of documentation. After years honing my craft within rigid corporate structures, I redirected my skills to serve those who truly need them: you.</p>
@@ -138,7 +63,7 @@
             <p>Identify your mission parameters. Specify your documentation requirements. No mission is impossible. No barrier is insurmountable. No system is impenetrable.</p>
         </section>
 
-        <section class="cta-section page-section content-card" style="text-align:center;">
+        <section class="cta-section page-section content-card text-center">
             <h2>READY TO INITIATE YOUR OPERATION?</h2>
             <p>Welcome to BuellDocs. Specify your requirements. Solutions will be deployed with precision and discretion.</p>
             <a href="#" class="btn btn-primary">Explore Services</a>

--- a/styles.css
+++ b/styles.css
@@ -146,6 +146,10 @@ label, input, select, textarea, button {
     letter-spacing: 0.5px;
 }
 
+.header-nav .nav-link.active {
+    color: var(--accent-gold);
+}
+
 .header-nav .nav-link:hover {
     color: var(--accent-gold);
 }
@@ -297,6 +301,68 @@ label, input, select, textarea, button {
     text-transform: uppercase;
     letter-spacing: 0.5px;
     font-weight: 600;
+}
+
+/* -------------------- */
+/* --- ABOUT PAGE STYLES --- */
+/* -------------------- */
+.about-main {
+    padding-top: calc(var(--header-height) + 30px);
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.page-section {
+    margin-bottom: 40px;
+}
+
+.content-card {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-md);
+    padding: 25px;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+}
+
+.terminal-card {
+    background-color: #111;
+    border-radius: var(--border-radius-md);
+    padding: 20px;
+    font-family: "Courier New", Courier, monospace;
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    position: relative;
+}
+
+.terminal-controls {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    display: flex;
+    gap: 6px;
+}
+
+.terminal-controls span {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.red { background-color: #ff5f56; }
+.yellow { background-color: #ffbd2e; }
+.green { background-color: #27c93f; }
+
+.text-center {
+    text-align: center;
+}
+
+footer {
+    padding: 20px 30px;
+    border-top: 1px solid var(--border-color-light);
+    text-align: center;
+    color: var(--text-tertiary);
+    font-size: 14px;
 }
 
 


### PR DESCRIPTION
## Summary
- remove inline CSS from `about_buelldocs.html`
- add About page classes to global stylesheet
- center call‑to‑action section via class
- highlight active nav link across pages

## Testing
- `tidy -errors about_buelldocs.html` *(fails: command not found)*
- `htmlhint about_buelldocs.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426b40c54c83208e4f0905898d71e6