### PR TITLE
Implement tax estimate inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,20 +381,15 @@
                     </div>
                     <div class="grid-col-2">
                         <div class="form-group">
-                            <label for="stateTaxName">State Tax Name</label>
-                            <input type="text" id="stateTaxName" name="stateTaxName" placeholder="e.g., NJ State Tax" aria-describedby="stateTaxNameError">
-                            <span class="error-message" id="stateTaxNameError"></span>
-                        </div>
-                        <div class="form-group">
-                            <label for="stateTaxAmount">State Tax Amount</label>
+                            <label for="stateTaxAmount">NJ State Tax</label>
                             <input type="number" id="stateTaxAmount" name="stateTaxAmount" step="0.01" min="0" value="0" aria-describedby="stateTaxAmountError">
                             <span class="error-message" id="stateTaxAmountError"></span>
                         </div>
-                    </div>
-                    <div class="form-group">
-                        <label for="medicareAmount">Medicare Amount</label>
-                        <input type="number" id="medicareAmount" name="medicareAmount" step="0.01" min="0" value="0" aria-describedby="medicareAmountError">
-                        <span class="error-message" id="medicareAmountError"></span>
+                        <div class="form-group">
+                            <label for="medicareAmount">Medicare</label>
+                            <input type="number" id="medicareAmount" name="medicareAmount" step="0.01" min="0" value="0" aria-describedby="medicareAmountError">
+                            <span class="error-message" id="medicareAmountError"></span>
+                        </div>
                     </div>
                     </div>
                 </section>
@@ -404,7 +399,7 @@
                     <h3>State-Specific Deductions/Taxes (New Jersey - Enter Amounts per Period)</h3>
                     <div class="grid-col-3">
                         <div class="form-group">
-                            <label for="njSdiAmount">NJ SDI Amount</label>
+                            <label for="njSdiAmount">NJ SUI/SDI (State Unemployment/Disability Insurance)</label>
                             <input type="number" id="njSdiAmount" name="njSdiAmount" step="0.01" min="0" value="0" aria-describedby="njSdiAmountError">
                             <span class="error-message" id="njSdiAmountError"></span>
                         </div>

--- a/script.js
+++ b/script.js
@@ -1880,6 +1880,13 @@ document.addEventListener('DOMContentLoaded', () => {
             document.getElementById('regularHours').value = assumedHours;
         }
 
+        const filingStatus = federalFilingStatusSelect ? federalFilingStatusSelect.value : 'Single';
+        const stateTaxInput = document.getElementById('stateTaxAmount');
+        if (stateTaxInput) {
+            const estState = estimateNJStateTax(grossPayPerPeriod, payFrequency, filingStatus);
+            stateTaxInput.value = estState.toFixed(2);
+        }
+
         if (forNJ) {
             const stateTaxNameInput = document.getElementById('stateTaxName');
             if (stateTaxNameInput && !stateTaxNameInput.value) stateTaxNameInput.value = 'NJ State Tax';


### PR DESCRIPTION
## Summary
- add dedicated NJ State Tax field and rename NJ SDI label
- auto-populate NJ State Tax using filing status when Step 1 calculate button is clicked

## Testing
- `npm test --prefix server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842845bbbf88320b231667fff23850e