### PR TITLE
Add employee info form

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
 
 
                 <!-- Employer Information -->
-                <section class="form-section-card form-section-minimized">
+                <section class="form-section-card">
                     <h3>Employer Information</h3>
                     <div class="grid-col-2">
                         <div class="form-group">
@@ -224,7 +224,7 @@
                     </div>
                     <div class="form-group">
                     <label for="employeeSsn">Employee SSN</label>
-                        <input type="text" id="employeeSsn" name="employeeSsn" placeholder="123-45-6789" aria-describedby="employeeSsnError">
+                        <input type="text" id="employeeSsn" name="employeeSsn" placeholder="***-**-1234" aria-describedby="employeeSsnError">
                         <span class="error-message" id="employeeSsnError"></span>
                         <p class="info-text ssn-info">SSN is used for display on the paystub and is not stored by BuellDocs for this generator tool. See our <a href='privacy_policy.html'>Privacy Policy</a>.</p>
                     </div>
@@ -232,23 +232,11 @@
                         <label for="federalFilingStatus">Federal Filing Status <span class="required-asterisk">*</span></label>
                         <select id="federalFilingStatus" name="federalFilingStatus" required aria-required="true" aria-describedby="federalFilingStatusError">
                             <option value="Single" selected>Single</option>
-                            <option value="Married Filing Jointly">Married Filing Jointly</option>
+                            <option value="Married Filing Jointly">Married filing jointly</option>
+                            <option value="Head of Household">Head of Household</option>
                         </select>
                         <span class="error-message" id="federalFilingStatusError"></span>
                     </div>
-                </section>
-                <div class="step-navigation">
-                    <button type="button" class="btn btn-secondary prev-step-btn">Previous Step</button>
-                    <button type="button" class="btn btn-primary next-step-btn">Next Step</button>
-                </div>
-            </div>
-                <div class="form-step">
-
-
-                <!-- Pay Period & Dates (For First/Base Stub) -->
-                <section class="form-section-card form-section-minimized">
-                    <h3>Pay Period & Dates (For First/Base Stub)</h3>
-                    <p class="info-text">For multiple stubs, later pay periods auto-increment based on the chosen frequency.</p>
                     <div class="grid-col-3">
                         <div class="form-group">
                             <label for="payPeriodStartDate">Pay Period Start Date <span class="required-asterisk">*</span></label>
@@ -267,6 +255,15 @@
                         </div>
                     </div>
                 </section>
+                <div class="step-navigation">
+                    <button type="button" class="btn btn-secondary prev-step-btn">Previous Step</button>
+                    <button type="button" class="btn btn-primary next-step-btn">Next Step</button>
+                </div>
+            </div>
+                <div class="form-step">
+
+
+
 
                 <!-- Earnings -->
                 <section class="form-section-card form-section-minimized">

--- a/script.js
+++ b/script.js
@@ -550,6 +550,27 @@ document.addEventListener('DOMContentLoaded', () => {
     currentPreviewStubIndex = 0;
     updatePreviewNavButtons();
 
+    const employeeSsnInput = document.getElementById('employeeSsn');
+    if (employeeSsnInput) {
+        let ssnRaw = '';
+        employeeSsnInput.addEventListener('input', e => {
+            const digits = e.target.value.replace(/\D/g, '').slice(0, 9);
+            ssnRaw = digits;
+            e.target.dataset.rawValue = ssnRaw;
+            e.target.value = digits.replace(/(\d{3})(\d{2})(\d{0,4})/, (m, p1, p2, p3) => p3 ? `${p1}-${p2}-${p3}` : `${p1}-${p2}`);
+        });
+        employeeSsnInput.addEventListener('blur', e => {
+            if (ssnRaw.length >= 4) {
+                e.target.value = `***-**-${ssnRaw.slice(-4)}`;
+            }
+        });
+        employeeSsnInput.addEventListener('focus', e => {
+            if (ssnRaw) {
+                e.target.value = ssnRaw.replace(/(\d{3})(\d{2})(\d{0,4})/, (m, p1, p2, p3) => `${p1}-${p2}-${p3}`);
+            }
+        });
+    }
+
 
 
     // Sidebar Button Actions
@@ -730,7 +751,10 @@ document.addEventListener('DOMContentLoaded', () => {
         for (let [key, value] of formData.entries()) {
             const inputElement = paystubForm.elements[key];
             if (inputElement) {
-                if (inputElement instanceof RadioNodeList) {
+                if (key === 'employeeSsn') {
+                    const raw = inputElement.dataset.rawValue || value;
+                    data[key] = raw.trim();
+                } else if (inputElement instanceof RadioNodeList) {
                     data[key] = value;
                 } else if (inputElement.type === 'radio') {
                     if (inputElement.checked) {


### PR DESCRIPTION
## Summary
- remove placeholder overlay and expand Employee Information section
- include pay period fields in the Employee Information step
- add filing status option for Head of Household
- mask SSN input visually and keep raw value for processing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68428446c57c8320abec0ae7e4e5feba