### PR TITLE
Enable live summary bar updates

### DIFF
--- a/script.js
+++ b/script.js
@@ -1256,9 +1256,20 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function updatePaystubTotals() {
-        livePreviewGrossPay.textContent = formatCurrency(calculateGrossPay());
-        livePreviewTotalDeductions.textContent = formatCurrency(calculateTotalDeductions());
-        livePreviewNetPay.textContent = formatCurrency(calculateNetPay());
+        const gross = calculateGrossPay();
+        const totalDeductions = calculateTotalDeductions();
+        const netPay = calculateNetPay();
+
+        livePreviewGrossPay.textContent = formatCurrency(gross);
+        livePreviewTotalDeductions.textContent = formatCurrency(totalDeductions);
+        livePreviewNetPay.textContent = formatCurrency(netPay);
+
+        // Also update the sticky summary bar at the bottom
+        if (summaryGrossPay && summaryTotalDeductions && summaryNetPay) {
+            summaryGrossPay.textContent = formatCurrency(gross);
+            summaryTotalDeductions.textContent = formatCurrency(totalDeductions);
+            summaryNetPay.textContent = formatCurrency(netPay);
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- update `updatePaystubTotals` to refresh sticky summary bar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842848035c483208f6d25af3477d683