### PR TITLE
Enhance wizard navigation and salary formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,7 +310,7 @@
                         <div class="grid-col-2">
                             <div class="form-group">
                                 <label for="annualSalary">Annual Salary <span class="required-asterisk">*</span></label>
-                                <input type="number" id="annualSalary" name="annualSalary" step="0.01" required aria-required="true" min="0" value="0" aria-describedby="annualSalaryError">
+                                <input type="text" id="annualSalary" name="annualSalary" class="form-input" inputmode="decimal" pattern="[0-9,\.]*" required aria-required="true" value="0.00" aria-describedby="annualSalaryError">
                                 <span class="error-message" id="annualSalaryError"></span>
                             </div>
                             <div class="form-group">

--- a/script.js
+++ b/script.js
@@ -316,7 +316,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function showFormStep(stepIndex) {
         formSteps.forEach((step, i) => {
-            step.style.display = i === stepIndex ? 'block' : 'none';
+            step.classList.toggle('active', i === stepIndex);
         });
         progressSteps.forEach((el, i) => {
             el.classList.toggle('active', i === stepIndex);
@@ -711,7 +711,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (type === 'Salaried') {
             document.querySelector('input[name="employmentType"][value="Salaried"]').checked = true;
             toggleEmploymentFields();
-            document.getElementById('annualSalary').value = annualAmount.toFixed(2);
+            document.getElementById('annualSalary').value = formatCurrencyInput(annualAmount);
         } else {
             document.querySelector('input[name="employmentType"][value="Hourly"]').checked = true;
             toggleEmploymentFields();
@@ -797,7 +797,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                 } else if (inputElement.type === 'checkbox') {
                     data[key] = inputElement.checked;
-                } else if (key === 'desiredIncomeAmount') {
+                } else if (key === 'desiredIncomeAmount' || key === 'annualSalary') {
                     data[key] = parseCurrencyValue(value) || 0;
                 } else if (inputElement.type === 'number' || inputElement.classList.contains('amount-input')) {
                     data[key] = parseFloat(value) || 0; // Ensure numbers, default to 0 if NaN
@@ -2042,7 +2042,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (repType === 'Salaried') {
             document.querySelector('input[name="employmentType"][value="Salaried"]').checked = true;
             const annualSalaryInput = document.getElementById('annualSalary');
-            annualSalaryInput.value = effectiveAnnualSalary.toFixed(2);
+            annualSalaryInput.value = formatCurrencyInput(effectiveAnnualSalary);
             const payFreqSelect = document.getElementById('salariedPayFrequency');
             if (payFreqSelect.value) payFrequency = payFreqSelect.value; else payFreqSelect.value = payFrequency;
             grossPayPerPeriod = effectiveAnnualSalary / PAY_PERIODS_PER_YEAR[payFrequency];
@@ -2681,6 +2681,19 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     updateAutoCalculatedFields();
     showFormStep(0);
+    const allFormInputs = document.querySelectorAll('#paystubForm input, #paystubForm select, #paystubForm textarea');
+    allFormInputs.forEach(inp => inp.addEventListener('input', updateLivePreview));
+
+    const annualSalaryInput = document.getElementById('annualSalary');
+    if (annualSalaryInput) {
+        annualSalaryInput.addEventListener('blur', function() {
+            let value = this.value.replace(/[^0-9.]/g, '');
+            if (value) {
+                value = parseFloat(value).toFixed(2);
+                this.value = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+            }
+        });
+    }
     validateDesiredIncome();
     if (sharePdfEmailLink) sharePdfEmailLink.style.display = 'none';
     if (sharePdfInstructions) sharePdfInstructions.style.display = 'none';

--- a/styles.css
+++ b/styles.css
@@ -1040,6 +1040,14 @@ input.invalid, select.invalid, textarea.invalid {
     margin-top: 5px;
 }
 
+.form-step {
+    display: none;
+}
+
+.form-step.active {
+    display: block;
+}
+
 .progress-indicator {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary
- switch salary field to text and format as USD
- hide/show form steps via `active` class
- parse annualSalary using currency helper
- track all form inputs for live preview
- add new CSS for wizard visibility

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684340cbb4e08320bb56ccaee49c6a8d