### PR TITLE
Fix step navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
             <form id="paystubForm">
                 <div id="formSummaryError" class="form-summary-error" aria-live="polite"></div>
                 <div id="formProgressIndicator" class="progress-indicator"></div>
-                <div class="form-step">
+                <div class="form-step" data-step="1">
                 <!-- Step 1: Desired Income Representation -->
                 <section class="form-section-card">
                     <h3>Step 1: Define Your Desired Income Representation</h3>
@@ -126,10 +126,10 @@
                     <button type="button" id="populateDetailsBtn" class="btn btn-primary">Calculate &amp; Fill Paystub Details &#10132;</button>
                 </section>
                 <div class="step-navigation">
-                    <button type="button" class="btn btn-primary next-step-btn">Next Step</button>
+                    <button type="button" class="btn btn-primary next-step">Next Step</button>
                 </div>
             </div>
-                <div class="form-step">
+                <div class="form-step" data-step="2">
 
 
                 <!-- Employer Information -->
@@ -261,11 +261,11 @@
                     </div>
                 </section>
                 <div class="step-navigation">
-                    <button type="button" class="btn btn-secondary prev-step-btn">Previous Step</button>
-                    <button type="button" class="btn btn-primary next-step-btn">Next Step</button>
+                    <button type="button" class="btn btn-secondary prev-step">Previous Step</button>
+                    <button type="button" class="btn btn-primary next-step">Next Step</button>
                 </div>
             </div>
-                <div class="form-step">
+                <div class="form-step" data-step="3">
 
 
 
@@ -346,11 +346,11 @@
                     </div>
                 </section>
                 <div class="step-navigation">
-                    <button type="button" class="btn btn-secondary prev-step-btn">Previous Step</button>
-                    <button type="button" class="btn btn-primary next-step-btn">Next Step</button>
+                    <button type="button" class="btn btn-secondary prev-step">Previous Step</button>
+                    <button type="button" class="btn btn-primary next-step">Next Step</button>
                 </div>
             </div>
-                <div class="form-step">
+                <div class="form-step" data-step="4">
 
 
                 <!-- Taxes (Enter Amounts per Period - Simulation Only) -->
@@ -436,11 +436,11 @@
                     </div>
                 </section>
                 <div class="step-navigation">
-                    <button type="button" class="btn btn-secondary prev-step-btn">Previous Step</button>
-                    <button type="button" class="btn btn-primary next-step-btn">Next Step</button>
+                    <button type="button" class="btn btn-secondary prev-step">Previous Step</button>
+                    <button type="button" class="btn btn-primary next-step">Next Step</button>
                 </div>
             </div>
-                <div class="form-step">
+                <div class="form-step" data-step="5">
 
 
                 <!-- Other Deductions (Optional) -->
@@ -508,11 +508,11 @@
                     </div>
                 </section>
                 <div class="step-navigation">
-                    <button type="button" class="btn btn-secondary prev-step-btn">Previous Step</button>
-                    <button type="button" class="btn btn-primary next-step-btn">Next Step</button>
+                    <button type="button" class="btn btn-secondary prev-step">Previous Step</button>
+                    <button type="button" class="btn btn-primary next-step">Next Step</button>
                 </div>
             </div>
-                <div class="form-step">
+                <div class="form-step" data-step="6">
 
 
                 <!-- Optional Additions -->
@@ -553,8 +553,8 @@
                     </div>
                 </section>
                 <div class="step-navigation">
-                    <button type="button" class="btn btn-secondary prev-step-btn">Previous Step</button>
-                    <button type="button" id="generateAndPay" class="btn btn-primary next-step-btn">Generate & Proceed to Payment</button>
+                    <button type="button" class="btn btn-secondary prev-step">Previous Step</button>
+                    <button type="button" id="generateAndPay" class="btn btn-primary next-step">Generate & Proceed to Payment</button>
                 </div>
             </div>
             </form>


### PR DESCRIPTION
## Summary
- manage form steps using `data-step` attributes
- use new `getCurrentStep()` helper to find the active step
- improve `showFormStep()` with bounds checks and debug logs
- delegate `.next-step` and `.prev-step` clicks on `document.body`
- update markup to include `data-step` and new navigation classes

## Testing
- `npm test --silent` *(fails: no test script)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6843445fa85c83209f362fb36b7902a5