### PR TITLE
Implement simple preview update system

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,14 @@
                 <p>Follow the new workflow below to quickly create your draft paystub.</p>
             </section>
 
+            <section id="quickPreview" class="form-section-card" aria-live="polite">
+                <h3>Quick Preview</h3>
+                <div class="paystub-preview">
+                    <p>Name: <span class="preview-name">John Doe</span></p>
+                    <p>Salary: <span class="preview-salary">$0</span></p>
+                </div>
+            </section>
+
             <form id="paystubForm">
                 <div id="formSummaryError" class="form-summary-error" aria-live="polite"></div>
                 <div id="formProgressIndicator" class="progress-indicator"></div>

--- a/script.js
+++ b/script.js
@@ -2667,6 +2667,47 @@ document.addEventListener('DOMContentLoaded', () => {
         openNotificationModal();
     }
 
+    // ---- New Live Preview System ---- //
+    const previewContainer = document.querySelector('.paystub-preview');
+    const fieldMappings = [
+        { input: '#employee-name, #employeeFullName', preview: '.preview-name', fallback: 'John Doe' },
+        { input: '#salary-input, #annualSalary', preview: '.preview-salary', fallback: '$0' },
+        { input: '#payDate', preview: '.preview-pay-date', fallback: 'YYYY-MM-DD' },
+        { input: '#companyName', preview: '.preview-company', fallback: 'Company Name' }
+    ];
+
+    function updateElement(selector, value) {
+        const el = previewContainer ? previewContainer.querySelector(selector) : null;
+        if (!el) {
+            console.error('Preview element missing for selector:', selector);
+            return;
+        }
+        el.textContent = value;
+    }
+
+    function updatePaystubPreview() {
+        console.error('updatePaystubPreview cycle start');
+        if (!previewContainer) {
+            console.error('Preview container not found');
+            return;
+        }
+        fieldMappings.forEach(map => {
+            const inputEl = document.querySelector(map.input);
+            const val = inputEl && inputEl.value.trim() ? inputEl.value.trim() : map.fallback;
+            updateElement(map.preview, val);
+        });
+    }
+
+    document.querySelectorAll('input, select, textarea').forEach(el => {
+        el.addEventListener('input', updatePaystubPreview);
+        el.addEventListener('blur', updatePaystubPreview);
+    });
+    document.querySelectorAll('.next-step-btn, .prev-step-btn').forEach(btn => {
+        btn.addEventListener('click', () => setTimeout(updatePaystubPreview, 0));
+    });
+
+    updatePaystubPreview();
+
     function setupActionButtons() {
         if (resetAllFieldsBtn) resetAllFieldsBtn.addEventListener('click', resetAllFormFields);
         if (saveDraftBtn) saveDraftBtn.addEventListener('click', saveDraftToLocalStorage);


### PR DESCRIPTION
## Summary
- add a quick preview section in `index.html`
- implement `updatePaystubPreview()` in `script.js`
- set up automatic live preview updates for all inputs, blurs and step navigation

## Testing
- `npm start` *(fails: no `npm` in container)*

------
https://chatgpt.com/codex/tasks/task_e_6843448b746c8320af7cc1e3085581ab