### PR TITLE
Add multi-step form CSS

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -543,9 +543,10 @@ input.auto-calc-readonly[readonly] {
 .form-summary-error.active {
     display: block;
 }
-input.invalid, select.invalid, textarea.invalid {
-    border-color: var(--error-color) !important;
-    box-shadow: 0 0 0 2px rgba(226, 93, 106, 0.3) !important; /* Red glow */
+/* Validation styling */
+.invalid {
+    border-color: #ff4444;
+    box-shadow: 0 0 5px rgba(255,68,68,0.5);
 }
 
 
@@ -1039,6 +1040,10 @@ input.invalid, select.invalid, textarea.invalid {
     border-radius: var(--border-radius-sm);
     margin-top: 5px;
 }
+/* Form step visibility */
+.form-step { display: none; }
+.form-step.active { display: block; }
+
 
 .progress-indicator {
     display: flex;
@@ -1047,21 +1052,16 @@ input.invalid, select.invalid, textarea.invalid {
 }
 
 .progress-step {
-    width: 20px;
-    height: 20px;
+    display: inline-block;
+    width: 25px;
+    height: 25px;
     border-radius: 50%;
-    background: var(--border-color);
-    color: var(--text-primary);
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    background: #ddd;
+    text-align: center;
     margin: 0 5px;
-    font-size: 12px;
 }
-
-.progress-step.active {
-    background: var(--accent-gold);
-}
+.progress-step.completed { background: #4CAF50; color: white; }
+.progress-step.active { background: #2196F3; color: white; }
 
 .step-navigation {
     display: flex;


### PR DESCRIPTION
## Summary
- style `.invalid` elements
- hide `.form-step` sections unless active
- tweak progress indicator styles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68434575f0088320816f05018281b274