### PR TITLE
Fix navigation button selectors

### DIFF
--- a/script.js
+++ b/script.js
@@ -55,7 +55,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const annualSalaryInput = document.getElementById('annualSalary');
 
-    const firstNextBtn = document.querySelector('.form-step .next-step-btn');
     const firstNextBtn = document.querySelector('.form-step .next-step');
 
     function parseCurrencyValue(val) {
@@ -434,7 +433,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const prevBtn = stepEl.querySelector('.prev-step');
             if (prevBtn) prevBtn.disabled = stepNumber === 1;
         }
-        const prevBtn = formSteps[stepIndex].querySelector('.prev-step-btn');
+        const prevBtn = formSteps[stepIndex].querySelector('.prev-step');
         if (prevBtn) prevBtn.disabled = stepIndex === 0;
         updateProgressIndicator(stepIndex + 1);
 
@@ -468,10 +467,8 @@ document.addEventListener('DOMContentLoaded', () => {
         return true;
     }
     function handleDelegatedStepButtons(e) {
-        const nextBtn = e.target.closest('.next-step-btn');
-        const prevBtn = e.target.closest('.prev-step-btn');
-    document.body.addEventListener('click', (e) => {
         const nextBtn = e.target.closest('.next-step');
+        const prevBtn = e.target.closest('.prev-step');
         if (nextBtn) {
             if (nextBtn.id === 'generateAndPay') {
                 if (validateAllFormFields()) {
@@ -484,24 +481,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 showFormStep(currentFormStep);
             }
         } else if (prevBtn) {
-            });
-        } else {
-            btn.addEventListener('click', function () {
-                if (DEBUG_MODE) console.log(`Attempting to validate step ${currentFormStep}`);
-                if (validateFormStep(currentFormStep)) {
-                    if (DEBUG_MODE) console.log(`Step ${currentFormStep} validation passed`);
-                if (validateStep(currentFormStep)) {
-                    currentFormStep = Math.min(currentFormStep + 1, formSteps.length - 1);
-                    if (DEBUG_MODE) console.log(`Navigating to step ${currentFormStep}`);
-                    showFormStep(currentFormStep);
-                } else {
-                    if (DEBUG_MODE) console.log(`Step ${currentFormStep} validation failed`);
-                }
-            });
+            const current = getCurrentStep();
+            showFormStep(current - 1);
         }
     }
 
-    const prevButtons = document.querySelectorAll('.prev-step-btn');
+    const prevButtons = document.querySelectorAll('.prev-step');
     for (let i = 0; i < prevButtons.length; i++) {
         const btn = prevButtons[i];
         btn.addEventListener('click', function () {
@@ -510,14 +495,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 currentFormStep--;
                 if (DEBUG_MODE) console.log(`Navigating to step ${currentFormStep}`);
                 showFormStep(currentFormStep);
-
             } else {
                 const current = getCurrentStep();
                 if (validateFormStep(current)) {
                     showFormStep(current + 1);
                 }
             }
-        }
+        });
     }
 
     function setupDelegatedButtonListeners() {
@@ -532,15 +516,6 @@ document.addEventListener('DOMContentLoaded', () => {
     function initializeAllInputHandlers() {
         setupActionButtons();
     }
-
-            return;
-        }
-        const prevBtn = e.target.closest('.prev-step');
-        if (prevBtn) {
-            const current = getCurrentStep();
-            showFormStep(current - 1);
-        }
-    });
 
     showFormStep(1);
 
@@ -2876,7 +2851,7 @@ document.addEventListener('DOMContentLoaded', () => {
         el.addEventListener('input', updatePaystubPreview);
         el.addEventListener('blur', updatePaystubPreview);
     });
-    document.querySelectorAll('.next-step-btn, .prev-step-btn').forEach(btn => {
+    document.querySelectorAll('.next-step, .prev-step').forEach(btn => {
         btn.addEventListener('click', () => setTimeout(updatePaystubPreview, 0));
     });
 


### PR DESCRIPTION
## Summary
- clean up navigation button classes in script.js
- use `.next-step`/`.prev-step` consistently

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843516064c08320ac8ef6f422fa1565