### PR TITLE
Improve salary field validation

### DIFF
--- a/script.js
+++ b/script.js
@@ -58,6 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const annualSalaryInput = document.getElementById('annualSalary');
 
     const firstNextBtn = document.querySelector('.form-step .next-step');
+    const salaryNextBtn = document.querySelector('[data-step="3"] .next-step');
 
     function parseCurrencyValue(val) {
         if (typeof val !== 'string') {
@@ -106,6 +107,18 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    function validateAnnualSalary() {
+        if (!annualSalaryInput) return true;
+        if (!isValidSalary(annualSalaryInput.value)) {
+            showError(annualSalaryInput, 'Please enter a valid salary amount.');
+            if (salaryNextBtn) salaryNextBtn.disabled = true;
+            return false;
+        }
+        clearError(annualSalaryInput);
+        if (salaryNextBtn) salaryNextBtn.disabled = false;
+        return true;
+    }
+
     function enablePopulateBtn() {
         if (populateDetailsBtn) {
             populateDetailsBtn.disabled = false;
@@ -134,20 +147,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (annualSalaryInput) {
         annualSalaryInput.addEventListener('input', () => {
-            if (!isValidSalary(annualSalaryInput.value)) {
-                annualSalaryInput.classList.add('invalid');
-            } else {
-                annualSalaryInput.classList.remove('invalid');
-            }
+            validateAnnualSalary();
             updateLivePreview();
-            console.log('Salary input changed');
         });
         annualSalaryInput.addEventListener('blur', () => {
-            if (isValidSalary(annualSalaryInput.value)) {
+            if (validateAnnualSalary()) {
                 annualSalaryInput.value = formatCurrencyInput(annualSalaryInput.value);
-                annualSalaryInput.classList.remove('invalid');
-            } else {
-                annualSalaryInput.classList.add('invalid');
             }
             updateLivePreview();
         });
@@ -2623,6 +2628,13 @@ document.addEventListener('DOMContentLoaded', () => {
             errorMessage = "Please enter a valid SSN (123-45-6789 or 123456789).";
         }
 
+        if (isValid && field.id === 'annualSalary') {
+            if (!isValidSalary(value)) {
+                isValid = false;
+                errorMessage = 'Please enter a valid salary amount.';
+            }
+        }
+
         if (isValid && field.type === 'number' && parseFloat(value) < 0) {
             isValid = false;
             errorMessage = 'Value cannot be negative.';
@@ -2938,15 +2950,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const annualSalaryInput = document.getElementById('annualSalary');
     if (annualSalaryInput) {
-        annualSalaryInput.addEventListener('blur', function() {
-            let value = this.value.replace(/[^0-9.]/g, '');
-            if (value) {
-                value = parseFloat(value).toFixed(2);
-                this.value = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+        annualSalaryInput.addEventListener('blur', () => {
+            if (validateAnnualSalary()) {
+                let value = annualSalaryInput.value.replace(/[^0-9.]/g, '');
+                if (value) {
+                    value = parseFloat(value).toFixed(2);
+                    annualSalaryInput.value = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+                }
             }
         });
     }
     validateDesiredIncome();
+    validateAnnualSalary();
     if (sharePdfEmailLink) sharePdfEmailLink.style.display = 'none';
     if (sharePdfInstructions) sharePdfInstructions.style.display = 'none';
     if (DEBUG_MODE) console.log('Initialization sequence completed');


### PR DESCRIPTION
## Summary
- add dedicated validateAnnualSalary handler
- disable step navigation when salary invalid
- show inline error for salary field
- call salary validation during initialization

## Testing
- `npm test --prefix server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843599754948320969084e6d313ac99