### PR TITLE
Fix live preview updates for all form field changes

### DIFF
--- a/script.js
+++ b/script.js
@@ -759,7 +759,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const debouncedPreview = debounce(updateLivePreview, 300);
     formInputs.forEach(input => {
         input.addEventListener('input', debouncedPreview);
-        input.addEventListener('change', debouncedPreview); // For selects, radios, checkboxes
+        if (input.tagName === 'SELECT' || input.type === 'checkbox' || input.type === 'radio') {
+            input.addEventListener('change', debouncedPreview);
+        }
         input.addEventListener('blur', () => validateField(input));
         input.addEventListener('input', () => {
             if (input.classList.contains('invalid')) {
@@ -2934,7 +2936,12 @@ document.addEventListener('DOMContentLoaded', () => {
     initStepNavigation();
     showActiveStep(0);
     const allFormInputs = document.querySelectorAll('#paystubForm input, #paystubForm select, #paystubForm textarea');
-    allFormInputs.forEach(inp => inp.addEventListener('input', updateLivePreview));
+    allFormInputs.forEach(inp => {
+        inp.addEventListener('input', debouncedPreview);
+        if (inp.tagName === 'SELECT' || inp.type === 'checkbox' || inp.type === 'radio') {
+            inp.addEventListener('change', debouncedPreview);
+        }
+    });
 
     const annualSalaryInput = document.getElementById('annualSalary');
     if (annualSalaryInput) {


### PR DESCRIPTION
## Summary
- debounce live preview updates for all form inputs
- ensure checkboxes and radio buttons trigger preview refresh on `change`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684359b73630832092f234694cfe23e0