### PR TITLE
Maintain placeholders in preview

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,6 +12,22 @@
 'use strict';
 
 const DEBUG_MODE = true;
+const PREVIEW_PLACEHOLDERS = {
+    companyName: "Your Company Name",
+    companyAddress1: "123 Main St",
+    companyCity: "Anytown",
+    companyState: "ST",
+    companyZip: "12345",
+    companyPhone: "Phone: (555) 123-4567",
+    companyEin: "EIN: XX-XXXXXXX",
+    employeeName: "Employee Name",
+    employeeAddress1: "456 Employee Ave",
+    employeeCity: "Workville",
+    employeeState: "ST",
+    employeeZip: "67890",
+    employeeSsn: "SSN: XXX-XX-1234",
+    date: "YYYY-MM-DD"
+};
 
 document.addEventListener('DOMContentLoaded', () => {
     if (DEBUG_MODE) console.log('Initialization sequence started');
@@ -1461,11 +1477,11 @@ document.addEventListener('DOMContentLoaded', () => {
         livePreviewStubXofY.textContent = `Stub ${currentPreviewStubIndex + 1} of ${numStubs}`;
 
         // Company Info
-        livePreviewCompanyName.textContent = displayDataForStub.companyName || 'Your Company Name';
-        livePreviewCompanyAddress1.textContent = displayDataForStub.companyStreetAddress || '123 Main St';
-        livePreviewCompanyAddress2.textContent = `${displayDataForStub.companyCity || 'Anytown'}, ${displayDataForStub.companyState || 'ST'} ${displayDataForStub.companyZip || '12345'}`;
-        livePreviewCompanyPhone.textContent = displayDataForStub.companyPhone ? `Phone: ${displayDataForStub.companyPhone}` : 'Phone: (555) 123-4567';
-        livePreviewCompanyEin.textContent = displayDataForStub.companyEin ? `EIN: ${displayDataForStub.companyEin}` : 'EIN: XX-XXXXXXX';
+        livePreviewCompanyName.textContent = displayDataForStub.companyName || PREVIEW_PLACEHOLDERS.companyName;
+        livePreviewCompanyAddress1.textContent = displayDataForStub.companyStreetAddress || PREVIEW_PLACEHOLDERS.companyAddress1;
+        livePreviewCompanyAddress2.textContent = `${displayDataForStub.companyCity || PREVIEW_PLACEHOLDERS.companyCity}, ${displayDataForStub.companyState || PREVIEW_PLACEHOLDERS.companyState} ${displayDataForStub.companyZip || PREVIEW_PLACEHOLDERS.companyZip}`;
+        livePreviewCompanyPhone.textContent = displayDataForStub.companyPhone ? `Phone: ${displayDataForStub.companyPhone}` : PREVIEW_PLACEHOLDERS.companyPhone;
+        livePreviewCompanyEin.textContent = displayDataForStub.companyEin ? `EIN: ${displayDataForStub.companyEin}` : PREVIEW_PLACEHOLDERS.companyEin;
         if (displayDataForStub.companyLogoDataUrl) {
             livePreviewCompanyLogo.src = displayDataForStub.companyLogoDataUrl;
             livePreviewCompanyLogo.style.display = 'block';
@@ -1474,14 +1490,14 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         // Employee Info
-        livePreviewEmployeeName.textContent = displayDataForStub.employeeFullName || 'Employee Name';
-        livePreviewEmployeeAddress1.textContent = displayDataForStub.employeeStreetAddress || '456 Employee Ave';
-        livePreviewEmployeeAddress2.textContent = `${displayDataForStub.employeeCity || 'Workville'}, ${displayDataForStub.employeeState || 'ST'} ${displayDataForStub.employeeZip || '67890'}`;
-        livePreviewEmployeeSsn.textContent = displayDataForStub.employeeSsn ? `SSN: ${maskSSN(displayDataForStub.employeeSsn)}` : 'SSN: XXX-XX-NNNN';
+        livePreviewEmployeeName.textContent = displayDataForStub.employeeFullName || PREVIEW_PLACEHOLDERS.employeeName;
+        livePreviewEmployeeAddress1.textContent = displayDataForStub.employeeStreetAddress || PREVIEW_PLACEHOLDERS.employeeAddress1;
+        livePreviewEmployeeAddress2.textContent = `${displayDataForStub.employeeCity || PREVIEW_PLACEHOLDERS.employeeCity}, ${displayDataForStub.employeeState || PREVIEW_PLACEHOLDERS.employeeState} ${displayDataForStub.employeeZip || PREVIEW_PLACEHOLDERS.employeeZip}`;
+        livePreviewEmployeeSsn.textContent = displayDataForStub.employeeSsn ? `SSN: ${maskSSN(displayDataForStub.employeeSsn)}` : PREVIEW_PLACEHOLDERS.employeeSsn;
 
-        livePreviewPayPeriodStart.textContent = displayDataForStub.payPeriodStartDate || 'YYYY-MM-DD';
-        livePreviewPayPeriodEnd.textContent = displayDataForStub.payPeriodEndDate || 'YYYY-MM-DD';
-        livePreviewPayDate.textContent = displayDataForStub.payDate || 'YYYY-MM-DD';
+        livePreviewPayPeriodStart.textContent = displayDataForStub.payPeriodStartDate || PREVIEW_PLACEHOLDERS.date;
+        livePreviewPayPeriodEnd.textContent = displayDataForStub.payPeriodEndDate || PREVIEW_PLACEHOLDERS.date;
+        livePreviewPayDate.textContent = displayDataForStub.payDate || PREVIEW_PLACEHOLDERS.date;
 
         livePreviewEarningsBody.innerHTML = '';
         if (displayDataForStub.employmentType === 'Hourly') {


### PR DESCRIPTION
## Summary
- define a `PREVIEW_PLACEHOLDERS` constants object
- reference these constants when updating live preview text

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68435d6111f483208ebadbd4a513cb90