### PR TITLE
Add custom checkbox styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -153,6 +153,46 @@ input.invalid, select.invalid, textarea.invalid { border-color: var(--error-colo
 .radio-group, .checkbox-group { display: flex; flex-wrap: wrap; gap: 10px 20px; align-items: center; }
 .radio-group label, .checkbox-group label { display: flex; align-items: center; text-transform: none; font-size: 15px; cursor: pointer; color: var(--text-secondary); }
 .radio-group input, .checkbox-group input { margin-right: 8px; accent-color: var(--accent-gold); transform: scale(1.1); }
+
+/* Custom checkbox styling */
+.checkbox-group input[type="checkbox"] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 18px;
+    height: 18px;
+    border: 2px solid var(--accent-gold);
+    border-radius: 3px;
+    background-color: transparent;
+    position: relative;
+    display: inline-block;
+    cursor: pointer;
+}
+
+.checkbox-group input[type="checkbox"]::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 6px;
+    height: 12px;
+    border: solid var(--bg-primary);
+    border-width: 0 2px 2px 0;
+    transform: translate(-50%, -60%) rotate(45deg);
+    opacity: 0;
+}
+
+.checkbox-group input[type="checkbox"]:checked {
+    background-color: var(--accent-gold);
+}
+
+.checkbox-group input[type="checkbox"]:checked::after {
+    opacity: 1;
+}
+
+.checkbox-group input[type="checkbox"]:focus-visible {
+    outline: 2px solid var(--accent-gold);
+    outline-offset: 2px;
+}
 .grid-col-2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; }
 .grid-col-3 { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 20px; }
 .info-text { font-size: 13px; color: var(--text-tertiary); margin-top: 5px; }


### PR DESCRIPTION
## Summary
- style checkboxes with yellow fill and dark checkmark

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843df49f77c8320a654a0579c12b0f7