### PR TITLE
Add NJ-focused state dropdown with alert

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,62 @@
                         <div class="form-group"><label for="companyStreetAddress">Company Street Address</label><input type="text" id="companyStreetAddress" name="companyStreetAddress" aria-describedby="companyStreetAddressError" maxlength="100"><span class="error-message" id="companyStreetAddressError"></span></div>
                         <div class="grid-col-3">
                             <div class="form-group"><label for="companyCity">City</label><input type="text" id="companyCity" name="companyCity" aria-describedby="companyCityError" maxlength="50"><span class="error-message" id="companyCityError"></span></div>
-                            <div class="form-group"><label for="companyState">State</label><input type="text" id="companyState" name="companyState" aria-describedby="companyStateError" maxlength="50"><span class="error-message" id="companyStateError"></span></div>
+                            <div class="form-group"><label for="companyState">State</label>
+                                <select id="companyState" name="companyState" aria-describedby="companyStateError">
+                                    <option value="">Select State</option>
+                                    <option value="NJ">New Jersey</option>
+                                    <option value="AL">Alabama</option>
+                                    <option value="AK">Alaska</option>
+                                    <option value="AZ">Arizona</option>
+                                    <option value="AR">Arkansas</option>
+                                    <option value="CA">California</option>
+                                    <option value="CO">Colorado</option>
+                                    <option value="CT">Connecticut</option>
+                                    <option value="DE">Delaware</option>
+                                    <option value="DC">District of Columbia</option>
+                                    <option value="FL">Florida</option>
+                                    <option value="GA">Georgia</option>
+                                    <option value="HI">Hawaii</option>
+                                    <option value="ID">Idaho</option>
+                                    <option value="IL">Illinois</option>
+                                    <option value="IN">Indiana</option>
+                                    <option value="IA">Iowa</option>
+                                    <option value="KS">Kansas</option>
+                                    <option value="KY">Kentucky</option>
+                                    <option value="LA">Louisiana</option>
+                                    <option value="ME">Maine</option>
+                                    <option value="MD">Maryland</option>
+                                    <option value="MA">Massachusetts</option>
+                                    <option value="MI">Michigan</option>
+                                    <option value="MN">Minnesota</option>
+                                    <option value="MS">Mississippi</option>
+                                    <option value="MO">Missouri</option>
+                                    <option value="MT">Montana</option>
+                                    <option value="NE">Nebraska</option>
+                                    <option value="NV">Nevada</option>
+                                    <option value="NH">New Hampshire</option>
+                                    <option value="NM">New Mexico</option>
+                                    <option value="NY">New York</option>
+                                    <option value="NC">North Carolina</option>
+                                    <option value="ND">North Dakota</option>
+                                    <option value="OH">Ohio</option>
+                                    <option value="OK">Oklahoma</option>
+                                    <option value="OR">Oregon</option>
+                                    <option value="PA">Pennsylvania</option>
+                                    <option value="RI">Rhode Island</option>
+                                    <option value="SC">South Carolina</option>
+                                    <option value="SD">South Dakota</option>
+                                    <option value="TN">Tennessee</option>
+                                    <option value="TX">Texas</option>
+                                    <option value="UT">Utah</option>
+                                    <option value="VT">Vermont</option>
+                                    <option value="VA">Virginia</option>
+                                    <option value="WA">Washington</option>
+                                    <option value="WV">West Virginia</option>
+                                    <option value="WI">Wisconsin</option>
+                                    <option value="WY">Wyoming</option>
+                                </select>
+                                <span class="error-message" id="companyStateError"></span></div>
                             <div class="form-group"><label for="companyZip">ZIP</label><input type="text" id="companyZip" name="companyZip" aria-describedby="companyZipError" maxlength="10"><span class="error-message" id="companyZipError"></span></div>
                         </div>
                         <hr>
@@ -140,7 +195,62 @@
                         <div class="form-group"><label for="employeeStreetAddress">Employee Address</label><input type="text" id="employeeStreetAddress" name="employeeStreetAddress" aria-describedby="employeeStreetAddressError" maxlength="100"><span class="error-message" id="employeeStreetAddressError"></span></div>
                         <div class="grid-col-3">
                             <div class="form-group"><label for="employeeCity">City</label><input type="text" id="employeeCity" name="employeeCity" aria-describedby="employeeCityError" maxlength="50"><span class="error-message" id="employeeCityError"></span></div>
-                            <div class="form-group"><label for="employeeState">State</label><input type="text" id="employeeState" name="employeeState" aria-describedby="employeeStateError" maxlength="50"><span class="error-message" id="employeeStateError"></span></div>
+                            <div class="form-group"><label for="employeeState">State</label>
+                                <select id="employeeState" name="employeeState" aria-describedby="employeeStateError">
+                                    <option value="">Select State</option>
+                                    <option value="NJ">New Jersey</option>
+                                    <option value="AL">Alabama</option>
+                                    <option value="AK">Alaska</option>
+                                    <option value="AZ">Arizona</option>
+                                    <option value="AR">Arkansas</option>
+                                    <option value="CA">California</option>
+                                    <option value="CO">Colorado</option>
+                                    <option value="CT">Connecticut</option>
+                                    <option value="DE">Delaware</option>
+                                    <option value="DC">District of Columbia</option>
+                                    <option value="FL">Florida</option>
+                                    <option value="GA">Georgia</option>
+                                    <option value="HI">Hawaii</option>
+                                    <option value="ID">Idaho</option>
+                                    <option value="IL">Illinois</option>
+                                    <option value="IN">Indiana</option>
+                                    <option value="IA">Iowa</option>
+                                    <option value="KS">Kansas</option>
+                                    <option value="KY">Kentucky</option>
+                                    <option value="LA">Louisiana</option>
+                                    <option value="ME">Maine</option>
+                                    <option value="MD">Maryland</option>
+                                    <option value="MA">Massachusetts</option>
+                                    <option value="MI">Michigan</option>
+                                    <option value="MN">Minnesota</option>
+                                    <option value="MS">Mississippi</option>
+                                    <option value="MO">Missouri</option>
+                                    <option value="MT">Montana</option>
+                                    <option value="NE">Nebraska</option>
+                                    <option value="NV">Nevada</option>
+                                    <option value="NH">New Hampshire</option>
+                                    <option value="NM">New Mexico</option>
+                                    <option value="NY">New York</option>
+                                    <option value="NC">North Carolina</option>
+                                    <option value="ND">North Dakota</option>
+                                    <option value="OH">Ohio</option>
+                                    <option value="OK">Oklahoma</option>
+                                    <option value="OR">Oregon</option>
+                                    <option value="PA">Pennsylvania</option>
+                                    <option value="RI">Rhode Island</option>
+                                    <option value="SC">South Carolina</option>
+                                    <option value="SD">South Dakota</option>
+                                    <option value="TN">Tennessee</option>
+                                    <option value="TX">Texas</option>
+                                    <option value="UT">Utah</option>
+                                    <option value="VT">Vermont</option>
+                                    <option value="VA">Virginia</option>
+                                    <option value="WA">Washington</option>
+                                    <option value="WV">West Virginia</option>
+                                    <option value="WI">Wisconsin</option>
+                                    <option value="WY">Wyoming</option>
+                                </select>
+                                <span class="error-message" id="employeeStateError"></span></div>
                             <div class="form-group"><label for="employeeZip">ZIP</label><input type="text" id="employeeZip" name="employeeZip" aria-describedby="employeeZipError" maxlength="10"><span class="error-message" id="employeeZipError"></span></div>
                         </div>
                     </section>

--- a/script.js
+++ b/script.js
@@ -130,6 +130,19 @@ document.addEventListener('DOMContentLoaded', () => {
         activeModal = dom.notificationModal;
     };
 
+    /**
+     * Alerts users when a non-New Jersey state is selected.
+     * @param {Event} e The change event from the state dropdown.
+     */
+    const handleStateChange = (e) => {
+        if (e.target.value && e.target.value !== 'NJ') {
+            showNotification(
+                'Auto-calculations are only available for New Jersey. This order will be treated as custom and may incur additional costs.',
+                'Custom Order Notice'
+            );
+        }
+    };
+
 
     // --- Multi-Step Form Logic --- //
     
@@ -726,9 +739,13 @@ function autoPopulateFromDesiredIncome() {
         dom.incomeRepresentationRadios.forEach(radio => radio.addEventListener('change', () => {
             dom.assumedHourlyHoursGroup.style.display = radio.value === 'Hourly' ? 'block' : 'none';
         }));
-         dom.startYtdFromBatch.addEventListener('change', () => {
+        dom.startYtdFromBatch.addEventListener('change', () => {
             dom.initialYtdFieldsContainer.style.display = dom.startYtdFromBatch.checked ? 'none' : 'block';
         });
+
+        // State dropdowns
+        if (dom.companyState) dom.companyState.addEventListener('change', handleStateChange);
+        if (dom.employeeState) dom.employeeState.addEventListener('change', handleStateChange);
 
         // Preview Navigation
         dom.prevStubBtn.addEventListener('click', () => { if (currentPreviewStubIndex > 0) { currentPreviewStubIndex--; renderPreviewForIndex(currentPreviewStubIndex); }});


### PR DESCRIPTION
## Summary
- replace plain text state fields with dropdowns
- show a notification when a state other than New Jersey is chosen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843e0fc2b788320a0f9dee1246a7333