### PR TITLE
Add input validation and formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,13 +126,13 @@
                         <h4>Employer Information</h4>
                         <div class="grid-col-2">
                             <div class="form-group"><label for="companyName">Company Name <span class="required-asterisk">*</span></label><input type="text" id="companyName" name="companyName" required aria-describedby="companyNameError" aria-required="true" maxlength="100"><span class="error-message" id="companyNameError"></span></div>
-                            <div class="form-group"><label for="companyPhone">Company Phone</label><input type="tel" id="companyPhone" name="companyPhone" placeholder="(###) ###-####" aria-describedby="companyPhoneError"><span class="error-message" id="companyPhoneError"></span></div>
+                            <div class="form-group"><label for="companyPhone">Company Phone</label><input type="tel" id="companyPhone" name="companyPhone" placeholder="123-456-7890" maxlength="12" aria-describedby="companyPhoneError"><span class="error-message" id="companyPhoneError"></span></div>
                         </div>
                         <div class="form-group"><label for="companyStreetAddress">Company Street Address</label><input type="text" id="companyStreetAddress" name="companyStreetAddress" aria-describedby="companyStreetAddressError" maxlength="100"><span class="error-message" id="companyStreetAddressError"></span></div>
                         <div class="grid-col-3">
                             <div class="form-group"><label for="companyCity">City</label><input type="text" id="companyCity" name="companyCity" aria-describedby="companyCityError" maxlength="50"><span class="error-message" id="companyCityError"></span></div>
                             <div class="form-group"><label for="companyState">State</label><input type="text" id="companyState" name="companyState" aria-describedby="companyStateError" maxlength="50"><span class="error-message" id="companyStateError"></span></div>
-                            <div class="form-group"><label for="companyZip">ZIP</label><input type="text" id="companyZip" name="companyZip" aria-describedby="companyZipError" maxlength="10"><span class="error-message" id="companyZipError"></span></div>
+                            <div class="form-group"><label for="companyZip">ZIP</label><input type="text" id="companyZip" name="companyZip" aria-describedby="companyZipError" maxlength="5" inputmode="numeric"><span class="error-message" id="companyZipError"></span></div>
                         </div>
                         <hr>
                         <h4>Employee Information</h4>
@@ -141,7 +141,7 @@
                         <div class="grid-col-3">
                             <div class="form-group"><label for="employeeCity">City</label><input type="text" id="employeeCity" name="employeeCity" aria-describedby="employeeCityError" maxlength="50"><span class="error-message" id="employeeCityError"></span></div>
                             <div class="form-group"><label for="employeeState">State</label><input type="text" id="employeeState" name="employeeState" aria-describedby="employeeStateError" maxlength="50"><span class="error-message" id="employeeStateError"></span></div>
-                            <div class="form-group"><label for="employeeZip">ZIP</label><input type="text" id="employeeZip" name="employeeZip" aria-describedby="employeeZipError" maxlength="10"><span class="error-message" id="employeeZipError"></span></div>
+                            <div class="form-group"><label for="employeeZip">ZIP</label><input type="text" id="employeeZip" name="employeeZip" aria-describedby="employeeZipError" maxlength="5" inputmode="numeric"><span class="error-message" id="employeeZipError"></span></div>
                         </div>
                     </section>
                     <div class="step-navigation">
@@ -184,7 +184,7 @@
                             <div class="grid-col-2">
                                 <div class="form-group">
                                     <label for="annualSalary">Annual Salary</label>
-                                    <input type="text" id="annualSalary" name="annualSalary" class="currency-input" required aria-required="true" value="$0.00" aria-describedby="annualSalaryError">
+                                    <input type="text" id="annualSalary" name="annualSalary" class="currency-input" required aria-required="true" value="$0.00" aria-describedby="annualSalaryError" inputmode="decimal">
                                     <span class="error-message" id="annualSalaryError"></span>
                                 </div>
                                 <div class="form-group">
@@ -327,7 +327,7 @@
                         <h4>User Details</h4>
                         <div class="form-group">
                             <label for="employeeSsn">Employee SSN</label>
-                            <input type="text" id="employeeSsn" name="employeeSsn" placeholder="***-**-1234" aria-describedby="employeeSsnError">
+                            <input type="text" id="employeeSsn" name="employeeSsn" placeholder="***-**-1234" maxlength="4" inputmode="numeric" aria-describedby="employeeSsnError">
                             <span class="error-message" id="employeeSsnError"></span>
                             <p class="info-text ssn-info">SSN is used for display on the paystub and is not stored by BuellDocs. See our <a href='privacy_policy.html'>Privacy Policy</a>.</p>
                         </div>

--- a/script.js
+++ b/script.js
@@ -120,6 +120,26 @@ document.addEventListener('DOMContentLoaded', () => {
         return parseFloat(String(value).replace(/[$,]/g, '')) || 0;
     };
 
+    /** Formats a 10-digit phone number as XXX-XXX-XXXX. */
+    const formatPhoneNumber = (value) => {
+        const digits = String(value).replace(/\D/g, '').slice(0, 10);
+        const parts = [];
+        if (digits.length > 0) parts.push(digits.slice(0, 3));
+        if (digits.length > 3) parts.push(digits.slice(3, 6));
+        if (digits.length > 6) parts.push(digits.slice(6));
+        return parts.join('-');
+    };
+
+    /** Restricts a value to 5 numeric ZIP digits. */
+    const formatZip = (value) => {
+        return String(value).replace(/\D/g, '').slice(0, 5);
+    };
+
+    /** Restricts a value to the last four digits of an SSN. */
+    const formatSsnLast4 = (value) => {
+        return String(value).replace(/\D/g, '').slice(0, 4);
+    };
+
     /**
      * Debounces a function to limit the rate at which it gets called.
      * @param {Function} func The function to debounce.
@@ -429,7 +449,7 @@ document.addEventListener('DOMContentLoaded', () => {
         dom.livePreviewEmployeeName.textContent = data.employeeFullName || 'Employee Name';
         dom.livePreviewEmployeeAddress1.textContent = data.employeeStreetAddress || '456 Employee Ave';
         dom.livePreviewEmployeeAddress2.textContent = `${data.employeeCity || 'Workville'}, ${data.employeeState || 'ST'} ${data.employeeZip || '67890'}`;
-        dom.livePreviewEmployeeSsn.textContent = data.employeeSsn ? `SSN: ${data.employeeSsn}` : 'SSN: XXX-XX-XXXX';
+        dom.livePreviewEmployeeSsn.textContent = data.employeeSsn ? `SSN: XXX-XX-${data.employeeSsn}` : 'SSN: XXX-XX-XXXX';
         
         // Dates (increment for each stub)
         const payFrequency = dom.employmentTypeRadios[0].checked ? dom.hourlyPayFrequency.value : dom.salariedPayFrequency.value;
@@ -731,6 +751,44 @@ function autoPopulateFromDesiredIncome() {
             }
             if (input.required) {
                  input.addEventListener('blur', () => validateField(input));
+            }
+        });
+
+        // Input formatting & restrictions
+        if (dom.companyPhone) {
+            dom.companyPhone.addEventListener('input', () => {
+                dom.companyPhone.value = formatPhoneNumber(dom.companyPhone.value);
+            });
+        }
+
+        [dom.companyZip, dom.employeeZip].forEach(zipInput => {
+            if (zipInput) {
+                zipInput.addEventListener('input', () => {
+                    zipInput.value = formatZip(zipInput.value);
+                });
+            }
+        });
+
+        if (dom.employeeSsn) {
+            dom.employeeSsn.addEventListener('input', () => {
+                dom.employeeSsn.value = formatSsnLast4(dom.employeeSsn.value);
+            });
+        }
+
+        if (dom.annualSalary) {
+            dom.annualSalary.addEventListener('input', () => {
+                dom.annualSalary.value = dom.annualSalary.value.replace(/[^0-9.]/g, '');
+            });
+            dom.annualSalary.addEventListener('blur', () => {
+                dom.annualSalary.value = formatCurrency(dom.annualSalary.value);
+            });
+        }
+
+        [dom.companyName, dom.employeeFullName, dom.companyCity, dom.employeeCity, dom.companyState, dom.employeeState].forEach(nameInput => {
+            if (nameInput) {
+                nameInput.addEventListener('input', () => {
+                    nameInput.value = nameInput.value.replace(/[^a-zA-Z\s]/g, '');
+                });
             }
         });
 


### PR DESCRIPTION
## Summary
- add helper functions to sanitize phone, ZIP, SSN, and currency fields
- auto-format phone numbers, ZIP codes, SSN last four, salary and name fields
- display SSN in preview with `XXX-XX-` prefix
- restrict relevant input lengths and modes in HTML

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6843e17e32d48320bde61204f2fd4e53