### PR TITLE
Implement confirmation preview modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,9 +52,6 @@
                 <button id="saveDraftBtn" class="btn btn-secondary btn-full-width">Save Draft</button>
                 <button id="loadDraftBtn" class="btn btn-secondary btn-full-width">Load Draft</button>
                 <button id="previewPdfWatermarkedBtn" class="btn btn-secondary btn-full-width">Preview PDF (Watermarked)</button>
-                <button id="copyKeyDataBtn" class="btn btn-secondary btn-full-width">Copy Key Paystub Data</button>
-                <a id="sharePdfEmailLink" class="btn btn-secondary btn-full-width" style="display:none;" href="mailto:?subject=BuellDocs Paystub Preview&amp;body=Please find my generated paystub preview attached. (Note: You will need to manually attach the PDF downloaded from BuellDocs.)">Share PDF via Email</a>
-                <p id="sharePdfInstructions" class="info-text" style="display:none;">First, download the PDF, then click here to open your email client. You'll need to manually attach the downloaded PDF.</p>
             </div>
         </aside>
 
@@ -625,7 +622,21 @@
             </div>
         </div>
     </div>
-    
+
+    <div id="confirmPreviewModal" class="modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="confirmPreviewTitle">
+        <div class="modal-content">
+            <span class="close-modal-btn" id="closeConfirmPreviewModalBtn">&times;</span>
+            <h2 id="confirmPreviewTitle">Paystub Preview</h2>
+            <div class="preview-watermark">BUELLDOCS</div>
+            <div id="confirmPreviewContainer" class="paystub-live-preview"></div>
+            <p class="confirmation-question">Are you satisfied with your paystub?</p>
+            <div class="confirmation-actions">
+                <button id="confirmPreviewProceedBtn" class="btn btn-primary">Proceed</button>
+                <button id="confirmPreviewEditBtn" class="btn btn-secondary">Edit</button>
+            </div>
+        </div>
+    </div>
+
     <div id="notificationModal" class="modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="notificationModalTitle">
         <div class="modal-content">
             <span class="close-modal-btn" id="closeNotificationModalBtn">&times;</span>

--- a/script.js
+++ b/script.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const elementIds = [
         'paystubForm', 'formProgressIndicator', 'formSummaryError', 'numPaystubs', 'hourlyPayFrequencyGroup',
         'hourlyPayFrequency', 'resetAllFieldsBtn', 'saveDraftBtn', 'loadDraftBtn', 'autoCalculateDeductionsBtn',
-        'previewPdfWatermarkedBtn', 'copyKeyDataBtn', 'sharePdfEmailLink', 'sharePdfInstructions',
+        'previewPdfWatermarkedBtn',
         'desiredIncomeAmount', 'desiredIncomePeriod', 'assumedHourlyHoursGroup', 'assumedHourlyRegularHours',
         'isForNJEmployment', 'netIncomeAdjustmentNote', 'populateDetailsBtn', 'hourlyFields', 'salariedFields',
         'hourlyRate', 'regularHours', 'overtimeHours', 'annualSalary', 'salariedPayFrequency',
@@ -47,7 +47,9 @@ document.addEventListener('DOMContentLoaded', () => {
         'cashAppTxId', 'confirmPaymentBtn', 'modalOrderSuccessMessage', 'closeSuccessMessageBtn',
         'successUserEmail', 'successUserEmailInline', 'successTxId', 'successNumStubs', 'successUserNotes',
         'supportEmailAddress', 'turnaroundTime', 'notificationModal', 'closeNotificationModalBtn',
-        'notificationModalTitle', 'notificationModalMessage', 'cashAppTxIdError'
+        'notificationModalTitle', 'notificationModalMessage', 'cashAppTxIdError',
+        'confirmPreviewModal', 'closeConfirmPreviewModalBtn', 'confirmPreviewContainer',
+        'confirmPreviewProceedBtn', 'confirmPreviewEditBtn'
     ];
     elementIds.forEach(id => { dom[id] = document.getElementById(id); });
     
@@ -694,16 +696,17 @@ function autoPopulateFromDesiredIncome() {
         }
     }
     
+    function openPreviewConfirmation() {
+        calculateAllStubsData();
+        renderPreviewForIndex(currentPreviewStubIndex);
+        dom.confirmPreviewContainer.innerHTML = dom.paystubPreviewContent.innerHTML;
+        dom.confirmPreviewModal.style.display = 'flex';
+        activeModal = dom.confirmPreviewModal;
+    }
+
     function handleMainFormSubmit() {
         if (!validateCurrentStep()) return;
-        const numStubs = parseInt(dom.numPaystubs.value, 10);
-        const pricingInfo = PRICING[numStubs] || PRICING[1];
-
-        dom.totalPaymentAmount.textContent = formatCurrency(pricingInfo.price);
-        dom.paymentDiscountNote.textContent = pricingInfo.note;
-        
-        dom.paymentModal.style.display = 'flex';
-        activeModal = dom.paymentModal;
+        openPreviewConfirmation();
     }
 
     function handlePaymentConfirmationSubmit() {
@@ -831,6 +834,17 @@ function autoPopulateFromDesiredIncome() {
         dom.closeNotificationModalBtn.addEventListener('click', () => closeModal(dom.notificationModal));
         dom.closeSuccessMessageBtn.addEventListener('click', () => closeModal(dom.paymentModal));
         dom.confirmPaymentBtn.addEventListener('click', handlePaymentConfirmationSubmit);
+        dom.closeConfirmPreviewModalBtn.addEventListener('click', () => closeModal(dom.confirmPreviewModal));
+        dom.confirmPreviewEditBtn.addEventListener('click', () => closeModal(dom.confirmPreviewModal));
+        dom.confirmPreviewProceedBtn.addEventListener('click', () => {
+            closeModal(dom.confirmPreviewModal);
+            const numStubs = parseInt(dom.numPaystubs.value, 10);
+            const pricingInfo = PRICING[numStubs] || PRICING[1];
+            dom.totalPaymentAmount.textContent = formatCurrency(pricingInfo.price);
+            dom.paymentDiscountNote.textContent = pricingInfo.note;
+            dom.paymentModal.style.display = 'flex';
+            activeModal = dom.paymentModal;
+        });
 
         // Global keydown/click for closing modals
         window.addEventListener('click', (e) => { if (e.target === activeModal) closeModal(activeModal); });

--- a/styles.css
+++ b/styles.css
@@ -264,6 +264,9 @@ input.invalid, select.invalid, textarea.invalid { border-color: var(--error-colo
 .voided-check-css { position: relative; background: var(--bg-tertiary); padding: 10px; font-family: 'Courier New', monospace; color: var(--text-secondary); font-size: 10px; }
 .void-text { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 40px; color: rgba(226, 93, 106, 0.7); font-weight: bold; z-index: 10; letter-spacing: 5px; border: 3px solid rgba(226, 93, 106, 0.7); padding: 0 10px; }
 
+.confirmation-question { text-align: center; margin: 20px 0; font-weight: 600; }
+.confirmation-actions { display: flex; justify-content: center; gap: 20px; }
+
 /* -------------------- */
 /* --- RESPONSIVE DESIGN --- */
 /* -------------------- */


### PR DESCRIPTION
## Summary
- remove unused preview controls
- add paystub confirmation modal with BUELLDOCS watermark
- wire modal into submit flow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843e3f0b4a483209f5c3f56de2aa233