### PR TITLE
Update order confirmation message

### DIFF
--- a/index.html
+++ b/index.html
@@ -610,14 +610,7 @@
 
             <div id="modalOrderSuccessMessage" style="display:none;">
                 <h3>Thank You!</h3>
-                <p><strong>Payment Processed (Simulated)!</strong> Your final, clean paystub(s) will be generated and emailed to <strong id="successUserEmailInline"></strong> typically <strong id="turnaroundTime">within 24 hours</strong> after your manual payment is confirmed by our team.</p>
-                <p>To ensure your order is processed correctly, please email a screenshot of your payment receipt and the following information to <strong id="supportEmailAddress">buellschool@gmail.com</strong>:</p>
-                <ul>
-                    <li>Email used on form: <strong id="successUserEmail"></strong></li>
-                    <li>Cash App/Payment Transaction ID entered: <strong id="successTxId"></strong></li>
-                    <li>Number of Stubs Requested: <strong id="successNumStubs"></strong></li>
-                    <li>Additional Notes/Custom Requests: <strong id="successUserNotes">None provided</strong></li>
-                </ul>
+                <p>Your order has been received. Your final, clean paystub(s) will be generated and emailed to <strong id="successUserEmailInline"></strong> typically <strong id="turnaroundTime">within 24 hours</strong>.</p>
                 <button id="closeSuccessMessageBtn" class="btn btn-secondary">Close</button>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -45,8 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
         'livePreviewNetPay', 'livePreviewPayrollProviderLogo', 'livePreviewVoidedCheckContainer',
         'paymentModal', 'closePaymentModalBtn', 'paymentInstructions', 'totalPaymentAmount', 'paymentDiscountNote',
         'cashAppTxId', 'confirmPaymentBtn', 'modalOrderSuccessMessage', 'closeSuccessMessageBtn',
-        'successUserEmail', 'successUserEmailInline', 'successTxId', 'successNumStubs', 'successUserNotes',
-        'supportEmailAddress', 'turnaroundTime', 'notificationModal', 'closeNotificationModalBtn',
+        'successUserEmailInline', 'turnaroundTime', 'notificationModal', 'closeNotificationModalBtn',
         'notificationModalTitle', 'notificationModalMessage', 'cashAppTxIdError',
         'confirmPreviewModal', 'closeConfirmPreviewModalBtn', 'confirmPreviewContainer',
         'confirmPreviewProceedBtn', 'confirmPreviewEditBtn'
@@ -721,11 +720,7 @@ function autoPopulateFromDesiredIncome() {
         dom.modalOrderSuccessMessage.style.display = 'block';
         
         // Populate success message details
-        dom.successUserEmail.textContent = dom.userEmail.value;
         dom.successUserEmailInline.textContent = dom.userEmail.value;
-        dom.successTxId.textContent = txIdInput.value;
-        dom.successNumStubs.textContent = dom.numPaystubs.value;
-        dom.successUserNotes.textContent = dom.userNotes.value || 'None provided';
     }
 
     function closeModal(modal) {


### PR DESCRIPTION
## Summary
- simplify the order confirmation modal to remove instructions and personal email
- update JS to match new confirmation message

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843e57405688320adb41fb55dc2a636