### PR TITLE
Add 2025 tax rate JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ To verify a build:
 3. Modify any field and check that the preview updates immediately.
 4. Watch the progress indicator to verify accurate tracking of the current step.
 5. Confirm that YTD values reflect the number of pay periods elapsed for the selected pay frequency.
+
+## Tax Rate Data
+
+The repository stores tax constants for calculations in a standalone JSON file located at `server/data/tax_rates_2025.json`. Updating the data for a new year only requires replacing this file or adding another year-specific JSON file, keeping the application logic unchanged.

--- a/server/data/tax_rates_2025.json
+++ b/server/data/tax_rates_2025.json
@@ -1,0 +1,66 @@
+{
+  "year": 2025,
+  "federal": {
+    "standardDeductions": {
+      "Single": 14600,
+      "MarriedJ": 29200,
+      "HeadOfHousehold": 21900
+    },
+    "taxBrackets": {
+      "Single": [
+        {"rate": 0.10, "from": 0, "to": 11600},
+        {"rate": 0.12, "from": 11600, "to": 47150},
+        {"rate": 0.22, "from": 47150, "to": 100525},
+        {"rate": 0.24, "from": 100525, "to": 191950},
+        {"rate": 0.32, "from": 191950, "to": 243725},
+        {"rate": 0.35, "from": 243725, "to": 609350},
+        {"rate": 0.37, "from": 609350, "to": "Infinity"}
+      ],
+      "MarriedJ": [
+        {"rate": 0.10, "from": 0, "to": 23200},
+        {"rate": 0.12, "from": 23200, "to": 94300},
+        {"rate": 0.22, "from": 94300, "to": 201050},
+        {"rate": 0.24, "from": 201050, "to": 383900},
+        {"rate": 0.32, "from": 383900, "to": 487450},
+        {"rate": 0.35, "from": 487450, "to": 731200},
+        {"rate": 0.37, "from": 731200, "to": "Infinity"}
+      ]
+    }
+  },
+  "fica": {
+    "socialSecurity": {
+      "rate": 0.062,
+      "wageLimit": 177300
+    },
+    "medicare": {
+      "rate": 0.0145,
+      "additionalRate": 0.009,
+      "additionalRateThreshold": 200000
+    }
+  },
+  "nj": {
+    "taxBrackets": {
+      "Single": [
+        {"rate": 0.014, "from": 0, "to": 20000},
+        {"rate": 0.0175, "from": 20000, "to": 35000},
+        {"rate": 0.035, "from": 35000, "to": 40000},
+        {"rate": 0.05525, "from": 40000, "to": 75000},
+        {"rate": 0.0637, "from": 75000, "to": 500000},
+        {"rate": 0.0897, "from": 500000, "to": 1000000},
+        {"rate": 0.1075, "from": 1000000, "to": "Infinity"}
+      ]
+    },
+    "sdi": {
+      "rate": 0.00,
+      "wageLimit": 169000
+    },
+    "fli": {
+      "rate": 0.0006,
+      "wageLimit": 169000
+    },
+    "ui_hc_wf": {
+      "rate": 0.00425,
+      "wageLimit": 43800
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add 2025 tax rates under `server/data`
- document tax rate file location in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844085c0ce08320a430ce8e40b3c73d