### PR TITLE
Integrate precision math module

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,6 +508,8 @@
     <footer>
         BUELLDOCS © 2025 | | <a href='privacy_policy.html'>Privacy Policy</a>
     </footer>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.8.0/math.min.js"></script>
+    <script src="js/precisionMath.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/js/precisionMath.js
+++ b/js/precisionMath.js
@@ -1,0 +1,81 @@
+/*
+    BuellDocs Precision Math Module
+    Description: Wraps math.js configured with BigNumber for high-precision,
+                 decimal-safe financial calculations.
+*/
+
+// Ensure math.js is loaded from a CDN before this script runs.
+if (typeof math === 'undefined') {
+    console.error('Math.js library not found. Please include it from a CDN.');
+} else {
+    // Configure math.js to use BigNumber for all calculations
+    math.config({
+        number: 'BigNumber',
+        precision: 64 // Default precision
+    });
+}
+
+/**
+ * Parses a value into a BigNumber, cleaning currency symbols and commas.
+ * @param {string|number} value The value to parse.
+ * @returns {math.BigNumber} A BigNumber instance.
+ */
+const toBig = (value) => {
+    if (value === null || typeof value === 'undefined') return math.bignumber(0);
+    const cleanedValue = String(value).replace(/[^0-9.-]+/g, '');
+    return math.bignumber(cleanedValue || 0);
+};
+
+/**
+ * A safe addition function.
+ * @param {...(string|number)} args Numbers to add.
+ * @returns {math.BigNumber} The sum as a BigNumber.
+ */
+const add = (...args) => args.reduce((acc, val) => math.add(acc, toBig(val)), math.bignumber(0));
+
+/**
+ * A safe subtraction function.
+ * @param {string|number} a The number to subtract from.
+ * @param {string|number} b The number to subtract.
+ * @returns {math.BigNumber} The difference as a BigNumber.
+ */
+const sub = (a, b) => math.subtract(toBig(a), toBig(b));
+
+/**
+ * A safe multiplication function.
+ * @param {...(string|number)} args Numbers to multiply.
+ * @returns {math.BigNumber} The product as a BigNumber.
+ */
+const mul = (...args) => args.reduce((acc, val) => math.multiply(acc, toBig(val)), math.bignumber(1));
+
+/**
+ * A safe division function.
+ * @param {string|number} a The dividend.
+ * @param {string|number} b The divisor.
+ * @returns {math.BigNumber} The quotient as a BigNumber.
+ */
+const div = (a, b) => {
+    const bigB = toBig(b);
+    if (bigB.isZero()) return math.bignumber(0);
+    return math.divide(toBig(a), bigB);
+};
+
+/**
+ * Formats a BigNumber into a standard currency string (e.g., "$1,234.56").
+ * @param {math.BigNumber|number|string} value The number to format.
+ * @returns {string} The formatted currency string.
+ */
+const format = (value) => {
+    const num = toBig(value).toNumber();
+    return num.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+};
+
+// Export the functions for use in other modules
+window.precisionMath = {
+    toBig,
+    add,
+    sub,
+    mul,
+    div,
+    format
+};


### PR DESCRIPTION
## Summary
- add `js/precisionMath.js` module to provide BigNumber-based helper functions
- load math.js and new module in `index.html`

## Testing
- `npm test --prefix server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684408bf99e88320b1a642bfc9e8b1eb