### PR TITLE
Integrate paystubEngine module

### DIFF
--- a/data/taxTables.json
+++ b/data/taxTables.json
@@ -1,0 +1,35 @@
+{
+  "fica": {
+    "socialSecurity": { "wageLimit": 168600, "rate": 0.062 },
+    "medicare": { "rate": 0.0145, "additionalRate": 0.009, "additionalRateThreshold": 200000 }
+  },
+  "federal": {
+    "standardDeductions": { "Single": 14600 },
+    "taxBrackets": {
+      "Single": [
+        { "from": 0, "to": 11600, "rate": 0.10 },
+        { "from": 11600, "to": 47150, "rate": 0.12 },
+        { "from": 47150, "to": 100525, "rate": 0.22 },
+        { "from": 100525, "to": 191950, "rate": 0.24 },
+        { "from": 191950, "to": 243725, "rate": 0.32 },
+        { "from": 243725, "to": 609350, "rate": 0.35 },
+        { "from": 609350, "to": "Infinity", "rate": 0.37 }
+      ]
+    }
+  },
+  "nj": {
+    "taxBrackets": {
+      "Single": [
+        { "from": 0, "to": 20000, "rate": 0.014 },
+        { "from": 20000, "to": 35000, "rate": 0.0175 },
+        { "from": 35000, "to": 40000, "rate": 0.035 },
+        { "from": 40000, "to": 75000, "rate": 0.05525 },
+        { "from": 75000, "to": 500000, "rate": 0.0637 },
+        { "from": 500000, "to": "Infinity", "rate": 0.0897 }
+      ]
+    },
+    "sdi": { "rate": 0.0, "wageLimit": 0 },
+    "fli": { "rate": 0.0006, "wageLimit": 156800 },
+    "ui_hc_wf": { "rate": 0.00425, "wageLimit": 42300 }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -508,6 +508,8 @@
     <footer>
         BUELLDOCS © 2025 | | <a href='privacy_policy.html'>Privacy Policy</a>
     </footer>
+    <script src="js/precisionMath.js"></script>
+    <script src="js/paystubEngine.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/js/paystubEngine.js
+++ b/js/paystubEngine.js
@@ -1,0 +1,139 @@
+/*
+    BuellDocs Paystub Engine v1.0
+    Description: A pure JavaScript module for calculating U.S. and NJ payroll taxes.
+                 It uses the precisionMath module for all calculations.
+*/
+window.paystubEngine = (() => {
+    let taxData = null; // To cache the loaded tax tables
+
+    // --- Data Loading ---
+    async function loadTaxData() {
+        if (taxData) return taxData;
+        try {
+            const response = await fetch('../data/taxTables.json');
+            if (!response.ok) throw new Error('Network response was not ok');
+            taxData = await response.json();
+            return taxData;
+        } catch (error) {
+            console.error('Failed to load tax tables:', error);
+            return null;
+        }
+    }
+
+    // --- Calculation Helpers ---
+    const { toBig, add, sub, mul, div } = window.precisionMath;
+
+    function calculateBracketedTax(annualIncome, brackets) {
+        let tax = toBig(0);
+        const income = toBig(annualIncome);
+
+        for (const bracket of brackets) {
+            const from = toBig(bracket.from);
+            const to = toBig(bracket.to === 'Infinity' ? Infinity : bracket.to);
+            if (income.gt(from)) {
+                const taxableInBracket = window.math.min(income, to).minus(from);
+                tax = add(tax, mul(taxableInBracket, bracket.rate));
+            }
+        }
+        return tax;
+    }
+
+    // --- Core Calculation Functions ---
+    function calcFICA(currentGross, ytdGross, fica) {
+        const { socialSecurity, medicare } = fica;
+        const currentGrossB = toBig(currentGross);
+        const ytdGrossB = toBig(ytdGross);
+
+        const ssLimit = toBig(socialSecurity.wageLimit);
+        const remainingSsTaxable = window.math.max(0, sub(ssLimit, ytdGrossB));
+        const currentSsTaxable = window.math.min(currentGrossB, remainingSsTaxable);
+        const ssTax = mul(currentSsTaxable, socialSecurity.rate);
+
+        let medicareTax = mul(currentGrossB, medicare.rate);
+        const totalGross = add(ytdGrossB, currentGrossB);
+        const medicareThreshold = toBig(medicare.additionalRateThreshold);
+        if (totalGross.gt(medicareThreshold)) {
+            const prevTaxed = window.math.max(medicareThreshold, ytdGrossB);
+            const additionalTaxable = sub(totalGross, prevTaxed);
+            medicareTax = add(medicareTax, mul(additionalTaxable, medicare.additionalRate));
+        }
+
+        return { socialSecurity: ssTax, medicare: medicareTax };
+    }
+
+    function calcFederal(grossPerPeriod, payPeriods, filingStatus, federal) {
+        const annualGross = mul(grossPerPeriod, payPeriods);
+        const deduction = toBig(federal.standardDeductions[filingStatus] || 0);
+        const taxableIncome = window.math.max(0, sub(annualGross, deduction));
+
+        const brackets = federal.taxBrackets[filingStatus] || [];
+        const annualTax = calculateBracketedTax(taxableIncome, brackets);
+
+        return div(annualTax, payPeriods);
+    }
+
+    function calcNJ(grossPerPeriod, ytdGross, payPeriods, nj) {
+        const currentGrossB = toBig(grossPerPeriod);
+        const ytdGrossB = toBig(ytdGross);
+
+        const annualGross = mul(currentGrossB, payPeriods);
+        const annualTax = calculateBracketedTax(annualGross, nj.taxBrackets.Single);
+        const stateTax = div(annualTax, payPeriods);
+
+        const calcCappedTax = (gross, ytd, rate, limit) => {
+            const remainingTaxable = window.math.max(0, sub(toBig(limit), ytdGrossB));
+            const currentTaxable = window.math.min(gross, remainingTaxable);
+            return mul(currentTaxable, rate);
+        };
+
+        const sdi = calcCappedTax(currentGrossB, ytdGrossB, nj.sdi.rate, nj.sdi.wageLimit);
+        const fli = calcCappedTax(currentGrossB, ytdGrossB, nj.fli.rate, nj.fli.wageLimit);
+        const ui_hc_wf = calcCappedTax(currentGrossB, ytdGrossB, nj.ui_hc_wf.rate, nj.ui_hc_wf.wageLimit);
+
+        return { stateTax, sdi, fli, ui_hc_wf };
+    }
+
+    function calculateAllTaxes(grossPerPeriod, ytdGross, payPeriods, filingStatus, otherDeductions) {
+        const { fica, federal, nj } = taxData;
+        const ficaTaxes = calcFICA(grossPerPeriod, ytdGross, fica);
+        const federalTax = calcFederal(grossPerPeriod, payPeriods, filingStatus, federal);
+        const njTaxes = calcNJ(grossPerPeriod, ytdGross, payPeriods, nj);
+
+        const totalTaxes = add(ficaTaxes.socialSecurity, ficaTaxes.medicare, federalTax, njTaxes.stateTax, njTaxes.sdi, njTaxes.fli, njTaxes.ui_hc_wf);
+        const totalDeductions = add(totalTaxes, otherDeductions);
+        const netPay = sub(grossPerPeriod, totalDeductions);
+
+        return {
+            grossPay: toBig(grossPerPeriod),
+            netPay: netPay,
+            totalDeductions,
+            federalTax,
+            ...ficaTaxes,
+            ...njTaxes
+        };
+    }
+
+    return {
+        init: loadTaxData,
+        calculate: calculateAllTaxes,
+        solveNetToGross: (desiredNet, payPeriods, filingStatus, otherDeductions) => {
+            if (!taxData) throw new Error("Tax data not loaded. Call init() first.");
+
+            let grossEstimate = mul(desiredNet, 1.5);
+            const desiredNetB = toBig(desiredNet);
+
+            for (let i = 0; i < 15; i++) {
+                const calcs = calculateAllTaxes(grossEstimate, 0, payPeriods, filingStatus, otherDeductions);
+                const currentNet = calcs.netPay;
+
+                const diff = sub(currentNet, desiredNetB);
+                if (window.math.abs(diff).lt(0.01)) {
+                    return grossEstimate;
+                }
+
+                grossEstimate = sub(grossEstimate, diff);
+            }
+            return grossEstimate;
+        }
+    };
+})();

--- a/js/precisionMath.js
+++ b/js/precisionMath.js
@@ -1,0 +1,27 @@
+(function(){
+    class BigNum {
+        constructor(value=0){
+            this.value = Number(value);
+        }
+        plus(v){ return new BigNum(this.value + Number(v instanceof BigNum ? v.value : v)); }
+        minus(v){ return new BigNum(this.value - Number(v instanceof BigNum ? v.value : v)); }
+        times(v){ return new BigNum(this.value * Number(v instanceof BigNum ? v.value : v)); }
+        div(v){ return new BigNum(this.value / Number(v instanceof BigNum ? v.value : v)); }
+        gt(v){ return this.value > Number(v instanceof BigNum ? v.value : v); }
+        toString(){ return String(this.value); }
+        valueOf(){ return this.value; }
+    }
+
+    function toBig(v){ return v instanceof BigNum ? v : new BigNum(v); }
+    function add(...vals){ return vals.reduce((acc,v)=>acc.plus(v), new BigNum(0)); }
+    function sub(a,b){ return toBig(a).minus(b); }
+    function mul(a,b){ return toBig(a).times(b); }
+    function div(a,b){ return toBig(a).div(b); }
+
+    window.precisionMath = { toBig, add, sub, mul, div };
+    window.math = {
+        min:(a,b)=> toBig((toBig(a).value < toBig(b).value) ? a : b),
+        max:(a,b)=> toBig((toBig(a).value > toBig(b).value) ? a : b),
+        abs:(a)=> toBig(Math.abs(toBig(a).value))
+    };
+})();


### PR DESCRIPTION
## Summary
- add a simple `precisionMath` helper library
- add `paystubEngine` with tax calculations
- include NJ and federal tax tables as JSON
- load new scripts in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68440935ad808320b3e66dba89fee58a