### PR TITLE
Add CDN math libs and module scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,6 +508,10 @@
     <footer>
         BUELLDOCS © 2025 | | <a href='privacy_policy.html'>Privacy Policy</a>
     </footer>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/12.4.2/math.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bignumber.js/9.1.2/bignumber.min.js"></script>
+    <script src="js/precisionMath.js"></script>
+    <script src="js/paystubEngine.js"></script>
     <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load mathjs and bignumber CDN libraries
- include precisionMath and paystubEngine modules before main script

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844096581848320ac7804817c211b54