### PR TITLE
Add main stylesheet with font imports

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,0 +1,145 @@
+/*
+  BuellDocs v4
+  main.css
+  ---
+  Main stylesheet for the Paystub Generator application.
+  Includes font imports, base styles, and utility classes.
+*/
+
+/*
+ * =================================================================================================
+ * FONT FACES
+ * =================================================================================================
+ * We are importing Inter for general UI text, Roboto Mono for numerical data to ensure alignment,
+ * and OCR-B for a classic, machine-readable look on the paystub preview itself.
+ */
+
+/* Inter: Regular, Bold */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
+/* Roboto Mono: Regular, Bold */
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap');
+
+/* OCR-B */
+/* Note: OCR-B is not available on Google Fonts. A local font file or an alternative is needed.
+   For now, we will use a fallback to a generic monospace font.
+   If you have the font files (e.g., woff2), they can be added like this:
+@font-face {
+    font-family: 'OCR-B';
+    src: url('../fonts/OCRB.woff2') format('woff2'),
+         url('../fonts/OCRB.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+}
+*/
+
+/*
+ * =================================================================================================
+ * ROOT VARIABLES
+ * =================================================================================================
+ * Defines the core color palette, typography, and spacing for consistency across the application.
+ */
+
+:root {
+  /* Colors */
+  --primary-color: #007bff;
+  --secondary-color: #6c757d;
+  --success-color: #28a745;
+  --danger-color: #dc3545;
+  --warning-color: #ffc107;
+  --info-color: #17a2b8;
+  --light-color: #f8f9fa;
+  --dark-color: #343a40;
+  --white-color: #ffffff;
+  --border-color: #dee2e6;
+
+  /* Typography */
+  --font-family-sans-serif: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-family-monospace: 'Roboto Mono', SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --font-family-ocr: 'OCR-B', var(--font-family-monospace); /* Fallback to Roboto Mono */
+
+
+  /* Spacing */
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 3rem;
+
+  /* Borders */
+  --border-radius: 0.375rem;
+  --border-width: 1px;
+
+  /* Shadows */
+  --box-shadow-sm: 0 .125rem .25rem rgba(0,0,0,.075);
+  --box-shadow: 0 .5rem 1rem rgba(0,0,0,.15);
+  --box-shadow-lg: 0 1rem 3rem rgba(0,0,0,.175);
+}
+
+
+/*
+ * =================================================================================================
+ * BASE & ELEMENT STYLES
+ * =================================================================================================
+ * Global styles for HTML elements for a clean, modern base.
+ */
+
+body {
+  font-family: var(--font-family-sans-serif);
+  line-height: 1.6;
+  background-color: var(--light-color);
+  color: var(--dark-color);
+  margin: 0;
+  padding: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 0;
+  margin-bottom: var(--spacing-sm);
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: var(--spacing-md);
+}
+
+a {
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/*
+ * =================================================================================================
+ * UTILITY CLASSES
+ * =================================================================================================
+ * Reusable helper classes for layout, typography, etc.
+ */
+
+.container {
+  width: 100%;
+  max-width: 1200px;
+  padding-right: var(--spacing-md);
+  padding-left: var(--spacing-md);
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.font-monospace {
+    font-family: var(--font-family-monospace);
+}
+
+.font-ocr {
+    font-family: var(--font-family-ocr);
+}


### PR DESCRIPTION
## Summary
- add a `css` directory with `main.css`
- import Inter and Roboto Mono fonts and provide placeholder instructions for OCR-B
- define root variables and basic styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845029760348320b97117f5bd11a3b2