### PR TITLE
Rename product references

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title> BuellDocs Paystub Generator Pro</title>
+    <title>BuellDocs Paystub Builder</title>
     
     <!-- Tailwind CSS for modern styling -->
     <script src="https://cdn.tailwindcss.com"></script>
@@ -50,7 +50,7 @@
     <div class="max-w-screen-2xl mx-auto p-4 sm:p-6 lg:p-8">
         <!-- Header -->
         <header class="mb-8">
-            <h1 class="font-display text-4xl font-bold text-slate-800">Paystub Generator <span class="text-indigo-600">Pro</span></h1>
+            <h1 class="font-display text-4xl font-bold text-slate-800">BuellDocs Paystub <span class="text-indigo-600">Builder</span></h1>
             <p class="text-lg text-slate-600 mt-1">Create, calculate, and download professional paystubs with ease.</p>
         </header>
 
@@ -218,7 +218,7 @@
         </main>
         
         <footer class="text-center mt-12 py-6">
-            <p class="text-sm text-gray-500">&copy; <span id="footer-year">2024</span> Paystub Generator Pro. All Rights Reserved.</p>
+            <p class="text-sm text-gray-500">&copy; <span id="footer-year">2024</span> BuellDocs Paystub Builder. All Rights Reserved.</p>
         </footer>
     </div>
     


### PR DESCRIPTION
## Summary
- rename the product from **Paystub Generator Pro** to **BuellDocs Paystub Builder** in the dashboard page

## Testing
- `npm test` in `server` (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68462d295f148320a2cdbd7920b90dfe