### PR TITLE
Add link to forklift operator PDF tool

### DIFF
--- a/about_buelldocs.html
+++ b/about_buelldocs.html
@@ -102,6 +102,7 @@
         <section class="about-hero page-section content-card">
             <h1>Meet <span style="color: var(--accent-gold);">The Architect</span></h1>
             <p>At 33, I've made it my mission to become the ultimate fixer—the Michael Clayton of documentation. After years honing my craft within rigid corporate structures, I redirected my skills to serve those who truly need them: you.</p>
+            <a href="ForliftCert.HTML" class="btn btn-success" style="margin-top:10px; display:inline-block;">Forklift Operator PDF</a>
         </section>
 
         <section class="terminal-card-section page-section">

--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
         <header class="mb-8">
             <h1 class="font-display text-4xl font-bold text-slate-800">Paystub Generator <span class="text-indigo-600">Pro</span></h1>
             <p class="text-lg text-slate-600 mt-1">Create, calculate, and download professional paystubs with ease.</p>
+            <a href="ForliftCert.HTML" class="inline-block mt-4 px-4 py-2 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700">Forklift Operator PDF</a>
         </header>
 
         <main class="grid grid-cols-1 lg:grid-cols-12 gap-8">


### PR DESCRIPTION
## Summary
- link to the Forklift Certification generator from the top of `index.html`
- add same link under the hero in `about_buelldocs.html`

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846dba7441483208aab89855e859983